### PR TITLE
Migrate to use generic helper finalizer

### DIFF
--- a/api/v1beta1/placementapi_types.go
+++ b/api/v1beta1/placementapi_types.go
@@ -26,10 +26,6 @@ import (
 )
 
 const (
-	// PlacementFinalizer allows PlacementAPIReconciler to clean up resources associated with PlacementAPI before
-	// removing it from the apiserver.
-	PlacementFinalizer = "placementapi.osp-director.openstack.org"
-
 	// DbSyncHash hash
 	DbSyncHash = "dbsync"
 

--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -148,7 +148,7 @@ func (r *PlacementAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, instance)
+		return r.reconcileDelete(ctx, instance, helper)
 	}
 
 	// Handle non-deleted clusters
@@ -170,11 +170,11 @@ func (r *PlacementAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *PlacementAPIReconciler) reconcileDelete(ctx context.Context, instance *placementv1.PlacementAPI) (ctrl.Result, error) {
+func (r *PlacementAPIReconciler) reconcileDelete(ctx context.Context, instance *placementv1.PlacementAPI, helper *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info("Reconciling Service delete")
 
 	// Service is deleted so remove the finalizer.
-	controllerutil.RemoveFinalizer(instance, placementv1.PlacementFinalizer)
+	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 	r.Log.Info("Reconciled Service delete successfully")
 	if err := r.Update(ctx, instance); err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
@@ -361,7 +361,7 @@ func (r *PlacementAPIReconciler) reconcileNormal(ctx context.Context, instance *
 	r.Log.Info("Reconciling Service")
 
 	// If the service object doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(instance, placementv1.PlacementFinalizer)
+	controllerutil.AddFinalizer(instance, helper.GetFinalizer())
 	// Register the finalizer immediately to avoid orphaning resources on delete
 	//if err := patchHelper.Patch(ctx, openStackCluster); err != nil {
 	if err := r.Update(ctx, instance); err != nil {

--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -266,7 +266,7 @@ func (r *PlacementAPIReconciler) reconcileInit(
 	// create users and endpoints - https://docs.openstack.org/placement/latest/install/install-rdo.html#configure-user-and-endpoints
 	// TODO: rework this
 	//
-	ospSecret, _, err := common.GetSecret(ctx, r, instance.Spec.Secret, instance.Namespace)
+	ospSecret, _, err := common.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Second * 10}, fmt.Errorf("OpenStack secret %s not found", instance.Spec.Secret)
@@ -374,7 +374,7 @@ func (r *PlacementAPIReconciler) reconcileNormal(ctx context.Context, instance *
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ospSecret, hash, err := common.GetSecret(ctx, r, instance.Spec.Secret, instance.Namespace)
+	ospSecret, hash, err := common.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Second * 10}, fmt.Errorf("OpenStack secret %s not found", instance.Spec.Secret)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.0
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openstack-k8s-operators/keystone-operator v0.0.0-20220627061212-1cb72024240c
-	github.com/openstack-k8s-operators/lib-common v0.0.0-20220624143132-2e80876a59f9
+	github.com/openstack-k8s-operators/lib-common v0.0.0-20220630111354-9f8383d4a2ea
 	github.com/openstack-k8s-operators/mariadb-operator v0.0.0-20220516121356-119f8d825a71
 	k8s.io/api v0.23.6
 	k8s.io/apimachinery v0.23.6

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,9 @@ github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9Pn
 github.com/openstack-k8s-operators/keystone-operator v0.0.0-20220627061212-1cb72024240c h1:W3qtJd1A3sIi3YKXryIQEm2FhvwtMxbTA00kkahiAiI=
 github.com/openstack-k8s-operators/keystone-operator v0.0.0-20220627061212-1cb72024240c/go.mod h1:wTpqPhpL+b0Y05M2xj4jsJu7g5DgbkM0Ze12gCy6i38=
 github.com/openstack-k8s-operators/lib-common v0.0.0-20220429114812-00cd552b97fa/go.mod h1:rdWrX7gVQF2bFvMDUu2iiy32p0e8jYDCMsu7fV2rBDk=
-github.com/openstack-k8s-operators/lib-common v0.0.0-20220624143132-2e80876a59f9 h1:LE1UqOjkkYSDauGBUNV4c9vqdiVdwLw8e3OAAGEX1IQ=
 github.com/openstack-k8s-operators/lib-common v0.0.0-20220624143132-2e80876a59f9/go.mod h1:sjH9zj16njdfy4PedlQGbJlwu9EXM2ugHhPA/l0zddM=
+github.com/openstack-k8s-operators/lib-common v0.0.0-20220630111354-9f8383d4a2ea h1:VDUbAuG4E4wxfAF2ElzSvE5XnrLHlsOjx7fXvQh3gzs=
+github.com/openstack-k8s-operators/lib-common v0.0.0-20220630111354-9f8383d4a2ea/go.mod h1:sjH9zj16njdfy4PedlQGbJlwu9EXM2ugHhPA/l0zddM=
 github.com/openstack-k8s-operators/mariadb-operator v0.0.0-20220516121356-119f8d825a71 h1:YdN/MEulSWdzc5KxBRkJ29gN0xTYqLri9FGvhkU5xk4=
 github.com/openstack-k8s-operators/mariadb-operator v0.0.0-20220516121356-119f8d825a71/go.mod h1:zdBCvR4p2D8PfyzVuUaXk1zIyo3kO6BPO8zTwSCWKBI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/21

Also updates GetSecret calls to use helper instead due to change and future removal of ReconcoilerCommon.