### PR TITLE
Increase Liveness/Readiness TimeoutSeconds

### DIFF
--- a/pkg/placement/deployment.go
+++ b/pkg/placement/deployment.go
@@ -40,11 +40,13 @@ func Deployment(
 
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
+		TimeoutSeconds:      5,
 		PeriodSeconds:       3,
 		InitialDelaySeconds: 3,
 	}
 	readinessProbe := &corev1.Probe{
 		// TODO might need tuning
+		TimeoutSeconds:      5,
 		PeriodSeconds:       5,
 		InitialDelaySeconds: 5,
 	}


### PR DESCRIPTION
Liveness and Readiness probes timed out on a small single node CRC
with 'Client.Timeout exceeded while awaiting headers'.

Lets increase the TimeoutSeconds from default 1s to 5s.