### PR TITLE
Run dependabot in ./api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: "gomod"
+  directory: "/api"
+  schedule:
+    interval: "daily"
+


### PR DESCRIPTION
We need to keep the main and the ./api go.mod file in sync so lets turn on dependabot on ./api too