### PR TITLE
Change make gotest to work with envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,9 +264,8 @@ govet: get-ci-tools
 	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/govet.sh ./api
 
 # Run go test against code
-gotest: get-ci-tools
-	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh
-	GOWORK=off $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh ./api
+gotest: get-ci-tools envtest
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh
 
 # Run golangci-lint test against code
 golangci: get-ci-tools


### PR DESCRIPTION
The current CI env expects to run our tests via the `make gotest` target so this patch makes sure that such target can be used to run our envtest based functional test.

This is needed for https://github.com/openshift/release/pull/34761/files to merge