### PR TITLE
[renovate]Run go work sync to keep go.mod files in sync

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["go mod tidy", "make manifests generate"],
+    "commands": ["make gowork", "go mod tidy", "make manifests generate"],
     "fileFilters": ["go.mod", "go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }


### PR DESCRIPTION
Renovate update deps in the two go.mod files independently. So it can miss the case when one go.mod update bumps an indirect dependency that is also part of the other go.mod file for a different reason. This can lead to divergent indirect dependencies in the two go.mod files.

This patch makes sure that renovate runs go work sync to keep the two mod files in sync during bump