### PR TITLE
Add omitempty tag for slices

### DIFF
--- a/api/bases/placement.openstack.org_placementapis.yaml
+++ b/api/bases/placement.openstack.org_placementapis.yaml
@@ -131,6 +131,7 @@ spec:
                         specified.
                       type: string
                   required:
+                  - endpoint
                   - ipAddressPool
                   type: object
                 type: array

--- a/api/v1beta1/placementapi_types.go
+++ b/api/v1beta1/placementapi_types.go
@@ -108,16 +108,16 @@ type PlacementAPISpec struct {
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExternalEndpoints, expose a VIP using a pre-created IPAddressPool
-	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints"`
+	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints,omitempty"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service
 type MetalLBConfig struct {
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=internal;public
 	// Endpoint, OpenStack endpoint this service maps to
 	Endpoint endpoint.Endpoint `json:"endpoint"`
@@ -141,7 +141,7 @@ type MetalLBConfig struct {
 
 	// +kubebuilder:validation:Optional
 	// LoadBalancerIPs, request given IPs from the pool if available. Using a list to allow dual stack (IPv4/IPv6) support
-	LoadBalancerIPs []string `json:"loadBalancerIPs"`
+	LoadBalancerIPs []string `json:"loadBalancerIPs,omitempty"`
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/config/crd/bases/placement.openstack.org_placementapis.yaml
+++ b/config/crd/bases/placement.openstack.org_placementapis.yaml
@@ -131,6 +131,7 @@ spec:
                         specified.
                       type: string
                   required:
+                  - endpoint
                   - ipAddressPool
                   type: object
                 type: array


### PR DESCRIPTION
Otherwise marshalling/unmarshalling CRDs with webhooks results in error
as it serializes these struct fields as "null".

`The KeystoneAPI "keystone" is invalid: spec.networkAttachmentDefinitions:
Invalid value: "null": spec.networkAttachmentDefinitions in body must be of
type array: "null"`