### PR TITLE
Extend the timeout for golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    errorlint
+run:
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
   rev: v1.50.1
   hooks:
     - id: golangci-lint
+      args: ["--verbose"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0


### PR DESCRIPTION
The default timeout is 1 minutes that seems to be not enough in CI. This is probably a fallout from the change where we limited the memory usage of golangci-lint in CI as that is expected to decrease the speed of the lint.