### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack mutatingwebhookconfiguration/mplacementapi.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export PLACEMENT_API_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+run-with-webhook: export PLACEMENT_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Kubernetes Operator built using the [Operator Framework](https://github.com/operator-framework) for Go.
 The Operator provides a way to easily install and manage an OpenStack Placement installation on Kubernetes.
-This Operator was developed using [RDO](https://www.rdoproject.org/) containers for openStack.
+This Operator was developed using [TCIB](https://github.com/openstack-k8s-operators/tcib/blob/main/container-images/containers.yaml) containers for OpenStack.
 
 # Deployment
 
@@ -19,7 +19,7 @@ kind: PlacementAPI
 metadata:
   name: placement
 spec:
-  containerImage: quay.io/tripleowallabycentos9/openstack-placement-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
   databaseInstance: openstack
   secret: placement-secret
 ```

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,4 +12,4 @@ spec:
       - name: manager
         env:
         - name: PLACEMENT_API_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified

--- a/config/samples/placement_v1beta1_placementapi.yaml
+++ b/config/samples/placement_v1beta1_placementapi.yaml
@@ -4,7 +4,7 @@ metadata:
   name: placement
 spec:
   serviceUser: placement
-  containerImage: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib