### PR TITLE
Add revive and ginkgolinter to golanci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,17 @@ linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
-    errorlint
+    - errorlint
+    - revive
+    - ginkgolinter
+    - gofmt
+    - govet
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: true
 run:
   timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,14 +23,10 @@ repos:
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1
   hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
     - id: go-mod-tidy
-    - id: go-lint
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.50.1
+  rev: v1.52.2
   hooks:
     - id: golangci-lint
       args: ["--verbose"]


### PR DESCRIPTION
We can replace deprecated go-linter using revive (https://golangci-lint.run/usage/linters/#revive). and also move gofmt and govet to golangci-lint