### PR TITLE
Bind all available addresses instead of 0.0.0.0

### DIFF
--- a/templates/placementapi/config/httpd.conf
+++ b/templates/placementapi/config/httpd.conf
@@ -8,7 +8,7 @@ ServerName "localhost.localdomain"
 User apache
 Group apache
 
-Listen 0.0.0.0:8778
+Listen 8778
 
 TypesConfig /etc/mime.types
 


### PR DESCRIPTION
... so that api can be accessed even when IPv6 is used for pod networks.