### PR TITLE
Add GINKGO_ARGS env var to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ vet: gowork ## Run go vet against code.
 .PHONY: test
 test: manifests generate gowork fmt vet envtest ginkgo ## Run tests.
 	# TODO(gibi): enable --randomize-all and fix test failures
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/placement,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} ./test/...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) -v debug --bin-dir $(LOCALBIN) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) --trace --cover --coverpkg=../../pkg/placement,../../controllers,../../api/v1beta1 --coverprofile cover.out --covermode=atomic ${PROC_CMD} $(GINKGO_ARGS) ./test/...
 
 ##@ Build
 


### PR DESCRIPTION
With this change you can pass arbitrary parameters to the ginkgo test executor via the make target.

E.g. if you want to run only a subset of test sequentially failing on the first error then you can do that with:

make test GINKGO_ARGS="--focus 'finalizer' --fail-fast  --procs 1"