### PR TITLE
Fix make tidy not to depend on ./bin path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,9 +326,10 @@ run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go
 
+APIPATH ?= $(shell pwd)/api
 .PHONY: tidy
 tidy: fmt
 	go mod tidy; \
-	pushd "$(LOCALBIN)/../api"; \
+	pushd $(APIPATH); \
 	go mod tidy; \
 	popd


### PR DESCRIPTION
We should not assume that ./bin exists as it is not part of the git repository but created dynamically.