### PR TITLE
Replace remaining references to TripleO images

### DIFF
--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: placement
   namespace: openstack
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true
@@ -106,7 +106,7 @@ spec:
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -153,7 +153,7 @@ spec:
           value: placement
         - name: DatabaseUser
           value: placement
-        image: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
         imagePullPolicy: IfNotPresent
         name: init
         resources: {}


### PR DESCRIPTION
These were missed when we merged https://github.com/openstack-k8s-operators/placement-operator/pull/143 , probably because of timing when kuttl tests were added.