### PR TITLE
Remove unused constant for admin endpoint

### DIFF
--- a/pkg/placement/const.go
+++ b/pkg/placement/const.go
@@ -23,8 +23,6 @@ const (
 	// DatabaseName -
 	DatabaseName = "placement"
 
-	// PlacementAdminPort -
-	PlacementAdminPort int32 = 8778
 	// PlacementPublicPort -
 	PlacementPublicPort int32 = 8778
 	// PlacementInternalPort -


### PR DESCRIPTION
The constant has not been used since we stopped creating admin endpoint.