### PR TITLE
Reset Ready condition when update failed

### DIFF
--- a/api/v1beta1/placementapi_types.go
+++ b/api/v1beta1/placementapi_types.go
@@ -231,14 +231,9 @@ func (instance PlacementAPI) GetEndpoint(endpointType endpoint.Endpoint) (string
 	return "", fmt.Errorf("%s endpoint not found", string(endpointType))
 }
 
-// IsReady - returns true if service is ready to server requests
+// IsReady - returns true if PlacementAPI is reconciled successfully
 func (instance PlacementAPI) IsReady() bool {
-
-	// Ready when:
-	// the service is registered in keystone
-	// AND
-	// there is at least a single pod service the placement service
-	return instance.Status.ServiceID != "" && instance.Status.ReadyCount >= 1
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // RbacConditionsSet - set the conditions for the rbac object

--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -142,11 +142,18 @@ func (r *PlacementAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err


### PR DESCRIPTION
This ensures the Ready Condition is reset when CR becomes once ready but something fails during reconfiguration.