### PR TITLE
Remove endpoint url and keystone service id from status

### DIFF
--- a/api/bases/placement.openstack.org_placementapis.yaml
+++ b/api/bases/placement.openstack.org_placementapis.yaml
@@ -241,11 +241,6 @@ spec:
           status:
             description: PlacementAPIStatus defines the observed state of PlacementAPI
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  type: string
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -308,9 +303,6 @@ spec:
                 description: ReadyCount of placement API instances
                 format: int32
                 type: integer
-              serviceID:
-                description: ServiceID - the ID of the registered service in keystone
-                type: string
             type: object
         type: object
     served: true

--- a/api/v1beta1/placementapi_types.go
+++ b/api/v1beta1/placementapi_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
-
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	endpoint "github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
@@ -181,17 +179,11 @@ type PlacementAPIStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoint,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// Placement Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
-
-	// ServiceID - the ID of the registered service in keystone
-	ServiceID string `json:"serviceID,omitempty"`
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
@@ -221,14 +213,6 @@ type PlacementAPIList struct {
 
 func init() {
 	SchemeBuilder.Register(&PlacementAPI{}, &PlacementAPIList{})
-}
-
-// GetEndpoint - returns OpenStack endpoint url for type
-func (instance PlacementAPI) GetEndpoint(endpointType endpoint.Endpoint) (string, error) {
-	if url, found := instance.Status.APIEndpoints[string(endpointType)]; found {
-		return url, nil
-	}
-	return "", fmt.Errorf("%s endpoint not found", string(endpointType))
 }
 
 // IsReady - returns true if PlacementAPI is reconciled successfully

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -204,13 +204,6 @@ func (in *PlacementAPIStatus) DeepCopyInto(out *PlacementAPIStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))

--- a/config/crd/bases/placement.openstack.org_placementapis.yaml
+++ b/config/crd/bases/placement.openstack.org_placementapis.yaml
@@ -241,11 +241,6 @@ spec:
           status:
             description: PlacementAPIStatus defines the observed state of PlacementAPI
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  type: string
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -308,9 +303,6 @@ spec:
                 description: ReadyCount of placement API instances
                 format: int32
                 type: integer
-              serviceID:
-                description: ServiceID - the ID of the registered service in keystone
-                type: string
             type: object
         type: object
     served: true

--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -197,9 +197,6 @@ func (r *PlacementAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
-	}
 	if instance.Status.NetworkAttachments == nil {
 		instance.Status.NetworkAttachments = map[string][]string{}
 	}
@@ -413,16 +410,6 @@ func (r *PlacementAPIReconciler) reconcileInit(
 		return ctrlResult, nil
 	}
 	instance.Status.Conditions.MarkTrue(condition.ExposeServiceReadyCondition, condition.ExposeServiceReadyMessage)
-
-	//
-	// Update instance status with service endpoint url from route host information
-	//
-	// TODO: need to support https default here
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
-	}
-	instance.Status.APIEndpoints = apiEndpoints
-
 	// expose service - end
 
 	//
@@ -453,14 +440,12 @@ func (r *PlacementAPIReconciler) reconcileInit(
 		return ctrlResult, nil
 	}
 
-	instance.Status.ServiceID = ksSvc.GetServiceID()
-
 	//
 	// register endpoints
 	//
 	ksEndptSpec := keystonev1.KeystoneEndpointSpec{
 		ServiceName: placement.ServiceName,
-		Endpoints:   instance.Status.APIEndpoints,
+		Endpoints:   apiEndpoints,
 	}
 	ksEndpt := keystonev1.NewKeystoneEndpoint(
 		placement.ServiceName,

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -262,15 +262,27 @@ metadata:
     kind: PlacementAPI
     name: placement
 ---
-# the actual addresses of the apiEndpoints are platform specific, so we can't rely on
+apiVersion: keystone.openstack.org/v1beta1
+kind: KeystoneEndpoint
+metadata:
+  name: placement
+  namespace: openstack
+  ownerReferences:
+  - apiVersion: placement.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlacementAPI
+    name: placement
+---
+# the actual addresses of the api endpoints are platform specific, so we can't rely on
 # kuttl asserts to check them. This short script gathers the addresses and checks that
-# the three endpoints are defined and their addresses follow the default pattern
+# the two endpoints are defined and their addresses follow the default pattern
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 namespaced: true
 commands:
   - script: |
       . $PLACEMENT_KUTTL_TEST_DIR/../lib/helper_functions.sh
-      apiEndpoints=$(oc get -n openstack PlacementAPI placement -o go-template-file=$PLACEMENT_KUTTL_TEST_DIR/../go_templates/apiEndpoints.gotemplate)
+      apiEndpoints=$(oc get -n openstack KeystoneEndpoint placement -o go-template-file=$PLACEMENT_KUTTL_TEST_DIR/../go_templates/apiEndpoints.gotemplate)
       assert_regex $apiEndpoints 'http:\/\/placement-internal\.openstack\.svc.*'
       assert_regex $apiEndpoints 'http:\/\/placement-public-openstack\.apps.*'

--- a/test/kuttl/go_templates/apiEndpoints.gotemplate
+++ b/test/kuttl/go_templates/apiEndpoints.gotemplate
@@ -1,1 +1,1 @@
-{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}
+{{.spec.endpoints.internal}}{{":"}}{{.spec.endpoints.public}}{{"\n"}}


### PR DESCRIPTION
These items presented in CR status are not really used. Endpoints can be discovered using Keystone and we have no use case to require service id.