### PR TITLE
Use DatabaseInstance to select the DB Service

### DIFF
--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -307,9 +307,10 @@ func (r *PlacementAPIReconciler) reconcileInit(
 		},
 	)
 	// create or patch the DB
-	ctrlResult, err := db.CreateOrPatchDB(
+	ctrlResult, err := db.CreateOrPatchDBByName(
 		ctx,
 		helper,
+		instance.Spec.DatabaseInstance,
 	)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(


### PR DESCRIPTION
The lib-common now has support to select the DB Service instance by the name of the MariaDB CR. The PlacementAPISpec already has that name passed in via the DatabaseInstance field. So this patch passes that input to lib-common.

Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/63