### PR TITLE
Sync the OWNERS file with the other repositories

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
 approvers:
-  - gibizer
-  - SeanMooney
-  - bogdando
-  - kk7ds
-  - stuggi
-  - mrKisaoLamb
+  - ci-approvers
+  - openstack-approvers
+  - compute-approvers
 
 reviewers:
-  - gibizer
-  - SeanMooney
-  - bogdando
-  - kk7ds
-  - stuggi
-  - mrKisaoLamb
+  - ci-approvers
+  - openstack-approvers
+  - compute-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,17 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  ci-approvers:
+  - Sandeepyadav93
+  - viroel
+  openstack-approvers:
+  - abays
+  - dprince
+  - olliewalsh
+  - stuggi
+  compute-approvers:
+  - gibizer
+  - SeanMooney
+  - bogdando
+  - kk7ds
+  - mrKisaoLamb


### PR DESCRIPTION
All the other repositories has the structure that allows approving patches for CI folks and the podified core team alongside with the repo specific approver group.

For some reason placement-operator repo was not synced to this structure when the rest of the repo was synced. But there was a discussion in slack[1] over it. There was some objection over this in slack. Lets try to conclude this now.

[1] https://redhat-internal.slack.com/archives/CQXJFGMK6/p1680527086750569