### PR TITLE
Prohibit updating spec.databaseInstance

### DIFF
--- a/api/bases/placement.openstack.org_placementapis.yaml
+++ b/api/bases/placement.openstack.org_placementapis.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: PlacementAPISpec defines the desired state of PlacementAPI
             properties:
+              advancedMode:
+                default: false
+                description: AdvancedMode - allows some usage not fully supported
+                  by this operator.
+                type: boolean
               containerImage:
                 description: PlacementAPI Container Image URL (will be set to environmental
                   default if empty)
@@ -60,9 +65,9 @@ spec:
                   file.
                 type: string
               databaseInstance:
-                description: MariaDB instance name Right now required by the maridb-operator
-                  to get the credentials from the instance to create the DB Might
-                  not be required in future
+                description: MariaDB instance name. This can't be updated unless advanced
+                  mode is enabled, because updating this does not migrate data to
+                  a new database instance.
                 type: string
               databaseUser:
                 default: placement

--- a/api/v1beta1/placementapi_types.go
+++ b/api/v1beta1/placementapi_types.go
@@ -46,9 +46,9 @@ type PlacementAPISpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Required
-	// MariaDB instance name
-	// Right now required by the maridb-operator to get the credentials from the instance to create the DB
-	// Might not be required in future
+	// MariaDB instance name.
+	// This can't be updated unless advanced mode is enabled, because updating this does not migrate
+	// data to a new database instance.
 	DatabaseInstance string `json:"databaseInstance"`
 
 	// +kubebuilder:validation:Optional
@@ -85,6 +85,11 @@ type PlacementAPISpec struct {
 	// Debug - enable debug for different deploy stages. If an init container is used, it runs and the
 	// actual action pod gets started with sleep infinity
 	Debug PlacementAPIDebug `json:"debug,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// AdvancedMode - allows some usage not fully supported by this operator.
+	AdvancedMode bool `json:"advancedMode"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false

--- a/api/v1beta1/placementapi_webhook.go
+++ b/api/v1beta1/placementapi_webhook.go
@@ -97,16 +97,18 @@ func (r *PlacementAPI) ValidateUpdate(old runtime.Object) error {
 		return apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
 	}
 
-	if r.Spec.DatabaseInstance != oldPlacement.Spec.DatabaseInstance {
-		return apierrors.NewForbidden(
-			schema.GroupResource{
-				Group:    GroupVersion.WithKind("PlacementAPI").Group,
-				Resource: GroupVersion.WithKind("PlacementAPI").Kind,
-			}, r.GetName(), field.Forbidden(
-				field.NewPath("spec").Child("databaseInstance"),
-				"Value is immutable",
-			),
-		)
+	if ! r.Spec.AdvancedMode {
+		if r.Spec.DatabaseInstance != oldPlacement.Spec.DatabaseInstance {
+			return apierrors.NewForbidden(
+				schema.GroupResource{
+					Group:    GroupVersion.WithKind("PlacementAPI").Group,
+					Resource: GroupVersion.WithKind("PlacementAPI").Kind,
+				}, r.GetName(), field.Forbidden(
+					field.NewPath("spec").Child("databaseInstance"),
+					"Value is immutable.",
+				),
+			)
+		}
 	}
 
 	return nil

--- a/config/crd/bases/placement.openstack.org_placementapis.yaml
+++ b/config/crd/bases/placement.openstack.org_placementapis.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: PlacementAPISpec defines the desired state of PlacementAPI
             properties:
+              advancedMode:
+                default: false
+                description: AdvancedMode - allows some usage not fully supported
+                  by this operator.
+                type: boolean
               containerImage:
                 description: PlacementAPI Container Image URL (will be set to environmental
                   default if empty)
@@ -60,9 +65,9 @@ spec:
                   file.
                 type: string
               databaseInstance:
-                description: MariaDB instance name Right now required by the maridb-operator
-                  to get the credentials from the instance to create the DB Might
-                  not be required in future
+                description: MariaDB instance name. This can't be updated unless advanced
+                  mode is enabled, because updating this does not migrate data to
+                  a new database instance.
                 type: string
               databaseUser:
                 default: placement

--- a/test/functional/placementapi_webhook_test.go
+++ b/test/functional/placementapi_webhook_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Placement webhook", func() {
 		placementAPI.Delete()
 	})
 
-	When("databaseInstance is being updated", func() {
+	When("databaseInstance is being updated with advanced mode default", func() {
 		It("should be blocked by the webhook and fail", func() {
 			instance := placementAPI.Instance
 			_, err := controllerutil.CreateOrPatch(
@@ -53,6 +53,35 @@ var _ = Describe("Placement webhook", func() {
 				})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("spec.databaseInstance: Forbidden: Value is immutable"))
+		})
+	})
+
+	When("databaseInstance is being updated with advanced mode disabled", func() {
+		It("should be blocked by the webhook and fail", func() {
+			instance := placementAPI.Instance
+
+			_, err := controllerutil.CreateOrPatch(
+				th.Ctx, th.K8sClient, instance, func() error {
+					instance.Spec.AdvancedMode = false
+					instance.Spec.DatabaseInstance = "changed"
+					return nil
+				})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("spec.databaseInstance: Forbidden: Value is immutable"))
+		})
+	})
+
+	When("databaseInstance is being updated with advanced mode disabled", func() {
+		It("should be blocked by the webhook and fail", func() {
+			instance := placementAPI.Instance
+
+			_, err := controllerutil.CreateOrPatch(
+				th.Ctx, th.K8sClient, instance, func() error {
+					instance.Spec.AdvancedMode = true
+					instance.Spec.DatabaseInstance = "changed"
+					return nil
+				})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/test/functional/placementapi_webhook_test.go
+++ b/test/functional/placementapi_webhook_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package functional_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ = Describe("Placement webhook", func() {
+
+	var placementAPI TestPlacementAPI
+
+	BeforeEach(func() {
+		// lib-common uses OPERATOR_TEMPLATES env var to locate the "templates"
+		// directory of the operator. We need to set them othervise lib-common
+		// will fail to generate the ConfigMap as it does not find common.sh
+		err := os.Setenv("OPERATOR_TEMPLATES", "../../templates")
+		Expect(err).NotTo(HaveOccurred())
+
+		placementAPI = NewTestPlacementAPI(TestNamespace)
+		placementAPI.Create()
+	})
+
+	AfterEach(func() {
+		placementAPI.Delete()
+	})
+
+	When("databaseInstance is being updated", func() {
+		It("should be blocked by the webhook and fail", func() {
+			instance := placementAPI.Instance
+			_, err := controllerutil.CreateOrPatch(
+				th.Ctx, th.K8sClient, instance, func() error {
+					instance.Spec.DatabaseInstance = "changed"
+					return nil
+				})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("spec.databaseInstance: Forbidden: Value is immutable"))
+		})
+	})
+})

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -18,8 +18,12 @@ package functional_test
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -168,6 +172,17 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 
+	// wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Duration(10) * time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -91,6 +91,13 @@ var _ = BeforeSuite(func() {
 			routev1CRDs,
 		},
 		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
+			// NOTE(gibi): if localhost is resolved to ::1 (ipv6) then starting
+			// the webhook fails as it try to parse the address as ipv4 and
+			// failing on the colons in ::1
+			LocalServingHost: "127.0.0.1",
+		},
 	}
 
 	// cfg is defined in this file globally.
@@ -127,13 +134,26 @@ var _ = BeforeSuite(func() {
 	Expect(th).NotTo(BeNil())
 
 	// Start the controller-manager if goroutine
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// NOTE(gibi): disable metrics reporting in test to allow
+		// parallel test execution. Otherwise each instance would like to
+		// bind to the same port
+		MetricsBindAddress: "0",
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
 	})
 	Expect(err).ToNot(HaveOccurred())
 
 	kclient, err := kubernetes.NewForConfig(cfg)
 	Expect(err).ToNot(HaveOccurred(), "failed to create kclient")
+
+	err = (&placementv1beta1.PlacementAPI{}).SetupWebhookWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = (&controllers.PlacementAPIReconciler{
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),


### PR DESCRIPTION
Updating spec.databaseInstance does not migrate existing data to a new instance and can break resource access unexpectedly. This prohibits such update.