### PR TITLE
Simplify condition check in kuttl tests

### DIFF
--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -26,58 +26,8 @@ status:
   databaseHostname: openstack
   readyCount: 1
   conditions:
-  - message: Setup complete
-    reason: Ready
-    status: "True"
+  - status: "True"
     type: Ready
-  - message: DB create completed
-    reason: Ready
-    status: "True"
-    type: DBReady
-  - message: DBsync completed
-    reason: Ready
-    status: "True"
-    type: DBSyncReady
-  - message: Deployment completed
-    reason: Ready
-    status: "True"
-    type: DeploymentReady
-  - message: Exposing service completed
-    reason: Ready
-    status: "True"
-    type: ExposeServiceReady
-  - message: Input data complete
-    reason: Ready
-    status: "True"
-    type: InputReady
-  - message: Setup complete
-    reason: Ready
-    status: "True"
-    type: KeystoneEndpointReady
-  - message: Setup complete
-    reason: Ready
-    status: "True"
-    type: KeystoneServiceReady
-  - message: NetworkAttachments completed
-    reason: Ready
-    status: "True"
-    type: NetworkAttachmentsReady
-  - message: RoleBinding created
-    reason: Ready
-    status: True
-    type: RoleBindingReady
-  - message: Role created
-    reason: Ready
-    status: "True"
-    type: RoleReady
-  - message: ServiceAccount created
-    reason: Ready
-    status: "True"
-    type: ServiceAccountReady
-  - message: Service config create completed
-    reason: Ready
-    status: "True"
-    type: ServiceConfigReady
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Currently we assert every single field in conditions but this requires updating the expected values in case any message is updated in the underlying dependencies.

Because we have env test which is more suitable to assert conditions, this simplifies the assertions in kuttl tests.