### PR TITLE
Watch RBAC resources to trigger reconcile

### DIFF
--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -223,6 +223,9 @@ func (r *PlacementAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&routev1.Route{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
This ensures the controller watches service account, role, and role bindings to reconcile these resources in case any change is made.