### PR TITLE
Revert "Fix cp -a permission issue in make manifests"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
-	rm -rf api/bases && cp -a config/crd/bases api/
+	rm -f api/bases/* && cp -a config/crd/bases api/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
This reverts commit 61624ae6e610fa26ebe5f63badb61a3db7080f59.

Reason for revert:
https://github.com/openshift/release/pull/41169 was merged which resolves the permission problem in CI. Thus we can revert the change and use the consistent command.