### PR TITLE
Skip redundant update when removing a finalizer

### DIFF
--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -59,26 +59,6 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// GetClient -
-func (r *PlacementAPIReconciler) GetClient() client.Client {
-	return r.Client
-}
-
-// GetKClient -
-func (r *PlacementAPIReconciler) GetKClient() kubernetes.Interface {
-	return r.Kclient
-}
-
-// GetLogger -
-func (r *PlacementAPIReconciler) GetLogger() logr.Logger {
-	return r.Log
-}
-
-// GetScheme -
-func (r *PlacementAPIReconciler) GetScheme() *runtime.Scheme {
-	return r.Scheme
-}
-
 // PlacementAPIReconciler reconciles a PlacementAPI object
 type PlacementAPIReconciler struct {
 	client.Client
@@ -251,11 +231,13 @@ func (r *PlacementAPIReconciler) reconcileDelete(ctx context.Context, instance *
 	}
 
 	if err == nil {
-		controllerutil.RemoveFinalizer(keystoneEndpoint, helper.GetFinalizer())
-		if err = helper.GetClient().Update(ctx, keystoneEndpoint); err != nil && !k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, err
+		if controllerutil.RemoveFinalizer(keystoneEndpoint, helper.GetFinalizer()) {
+			err = r.Update(ctx, keystoneEndpoint)
+			if err != nil && !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+			util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 		}
-		util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 	}
 
 	// Remove the finalizer from our KeystoneService CR
@@ -265,11 +247,13 @@ func (r *PlacementAPIReconciler) reconcileDelete(ctx context.Context, instance *
 	}
 
 	if err == nil {
-		controllerutil.RemoveFinalizer(keystoneService, helper.GetFinalizer())
-		if err = helper.GetClient().Update(ctx, keystoneService); err != nil && !k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, err
+		if controllerutil.RemoveFinalizer(keystoneService, helper.GetFinalizer()) {
+			err = r.Update(ctx, keystoneService)
+			if err != nil && !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+			util.LogForObject(helper, "Removed finalizer from our KeystoneService", instance)
 		}
-		util.LogForObject(helper, "Removed finalizer from our KeystoneService", instance)
 	}
 
 	// We did all the cleanup on the objects we created so we can remove the


### PR DESCRIPTION
We don't have to update a CR when the CR does not contain the finalizer being removed. This also removes some unused/redundant function from the Reconciler struct.