### PR TITLE
[envtest]Use database helpers from mariadb-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4
 	github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20230602092913-53f380989946
 	go.uber.org/zap v1.26.0
 	k8s.io/api v0.26.9

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.2023092
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20230927082538-4f614f333d17/go.mod h1:+iJZo5alCeOGD/524hWWdlINA6zqY+MjfWT7cDcbvBE=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17 h1:zJguNin+9IwRnGKy1A7ranxASKO1vTvWxoXwkCz8MWw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17/go.mod h1:YOFHrNK/QqCvZUPlDJYmDyaCkbKIB98V04uyofiC9a8=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c h1:9R8T1WRwuPS5KMfsQWxAMSGPuJrGMJ7bODKK9dirhHA=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c/go.mod h1:xXHF/R/L0XamRHR/UkzlgzSTocBQ6GSQ2U16Q9Mf/bA=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4 h1:37bbJ9XzpCvB+zZckdweJEEH3pqM6Q88OHH8eHFvlpI=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tests/functional/placementapi_controller_test.go
+++ b/tests/functional/placementapi_controller_test.go
@@ -244,16 +244,16 @@ var _ = Describe("PlacementAPI controller", func() {
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(namespace, "openstack", serviceSpec),
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
-			db := th.GetMariaDBDatabase(names.MariaDBDatabaseName)
+			db := mariadb.GetMariaDBDatabase(names.MariaDBDatabaseName)
 			// FIXME(gibi): this should be hardcoded to "placement" as this is
 			// the name of the DB schema to be created
 			Expect(db.Spec.Name).To(Equal(names.PlacementAPIName.Name))
 			Expect(db.Spec.Secret).To(Equal(SecretName))
 
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 
 			th.ExpectCondition(
 				names.PlacementAPIName,
@@ -272,10 +272,10 @@ var _ = Describe("PlacementAPI controller", func() {
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(namespace, "openstack", serviceSpec),
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
 
@@ -296,10 +296,10 @@ var _ = Describe("PlacementAPI controller", func() {
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(namespace, "openstack", serviceSpec),
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 
 			keystone.SimulateKeystoneEndpointReady(names.KeystoneEndpointName)
 
@@ -313,10 +313,10 @@ var _ = Describe("PlacementAPI controller", func() {
 		It("runs db sync", func() {
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(namespace, "openstack", serviceSpec),
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 
 			th.ExpectCondition(
 				names.PlacementAPIName,
@@ -365,10 +365,10 @@ var _ = Describe("PlacementAPI controller", func() {
 		It("creates deployment", func() {
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(namespace, "openstack", serviceSpec),
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 
 			th.ExpectCondition(
@@ -401,10 +401,10 @@ var _ = Describe("PlacementAPI controller", func() {
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(namespace, "openstack", serviceSpec),
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 			th.SimulateDeploymentReplicaReady(names.DeploymentName)
 
@@ -431,10 +431,10 @@ var _ = Describe("PlacementAPI controller", func() {
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(namespace, "openstack", serviceSpec),
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
 			keystone.SimulateKeystoneEndpointReady(names.KeystoneEndpointName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
@@ -480,8 +480,8 @@ var _ = Describe("PlacementAPI controller", func() {
 
 			placementAPI := CreatePlacementAPI(names.PlacementAPIName, spec)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetPlacementAPI(names.PlacementAPIName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -490,7 +490,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				),
 			)
 
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 			th.SimulateDeploymentReplicaReady(names.DeploymentName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
@@ -551,8 +551,8 @@ var _ = Describe("PlacementAPI controller", func() {
 
 			placementAPI := CreatePlacementAPI(names.PlacementAPIName, spec)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					namespace,
 					GetPlacementAPI(names.PlacementAPIName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -561,7 +561,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				),
 			)
 
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 			th.SimulateDeploymentReplicaReady(names.DeploymentName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
@@ -593,10 +593,10 @@ var _ = Describe("PlacementAPI controller", func() {
 
 			serviceSpec := corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 3306}}}
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(namespace, "openstack", serviceSpec),
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
-			th.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
 			keystone.SimulateKeystoneEndpointReady(names.KeystoneEndpointName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
@@ -617,7 +617,7 @@ var _ = Describe("PlacementAPI controller", func() {
 			Expect(keystoneService.Finalizers).To(ContainElement("PlacementAPI"))
 			keystoneEndpoint := keystone.GetKeystoneService(names.KeystoneEndpointName)
 			Expect(keystoneEndpoint.Finalizers).To(ContainElement("PlacementAPI"))
-			db := th.GetMariaDBDatabase(names.MariaDBDatabaseName)
+			db := mariadb.GetMariaDBDatabase(names.MariaDBDatabaseName)
 			Expect(db.Finalizers).To(ContainElement("PlacementAPI"))
 
 			th.DeleteInstance(GetPlacementAPI(names.PlacementAPIName))
@@ -626,7 +626,7 @@ var _ = Describe("PlacementAPI controller", func() {
 			Expect(keystoneService.Finalizers).NotTo(ContainElement("PlacementAPI"))
 			keystoneEndpoint = keystone.GetKeystoneService(names.KeystoneEndpointName)
 			Expect(keystoneEndpoint.Finalizers).NotTo(ContainElement("PlacementAPI"))
-			db = th.GetMariaDBDatabase(names.MariaDBDatabaseName)
+			db = mariadb.GetMariaDBDatabase(names.MariaDBDatabaseName)
 			Expect(db.Finalizers).NotTo(ContainElement("PlacementAPI"))
 		})
 

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -47,6 +47,7 @@ import (
 
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
+	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -62,6 +63,7 @@ var (
 	logger    logr.Logger
 	th        *common_test.TestHelper
 	keystone  *keystone_test.TestHelper
+	mariadb   *mariadb_test.TestHelper
 	namespace string
 	names     Names
 )
@@ -135,7 +137,9 @@ var _ = BeforeSuite(func() {
 	th = common_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(th).NotTo(BeNil())
 	keystone = keystone_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
-	Expect(th).NotTo(BeNil())
+	Expect(keystone).NotTo(BeNil())
+	mariadb = mariadb_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
+	Expect(mariadb).NotTo(BeNil())
 
 	// Start the controller-manager if goroutine
 	webhookInstallOptions := &testEnv.WebhookInstallOptions


### PR DESCRIPTION
This is necessary to remove a dependency cycle from lib-common