### PR TITLE
update structured logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("PlacementAPI"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PlacementAPI")
 		os.Exit(1)

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -168,7 +168,6 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("PlacementAPI"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

2023-09-16T23:17:59.334Z        INFO    Starting Controller     {"controller": "placementapi", "controllerGroup": "placement.openstack.org", "controllerKind": "PlacementAPI"} 

after:

2023-09-16T23:15:42.270Z        INFO    Controllers.PlacementAPI        Reconciling Service update      {" controller": "placementapi", "controllerGroup": "placement.openstack.org", "controllerKind": "PlacementAPI", "PlacementAPI": {"name":"placement","namespace":"openstack"}, "namespace": "openstack", "name": "placement", "reconcileID": "74348223-8529-4fec-aeab-7e2e4e050683"}     

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.
