### PR TITLE
Use instance.Name in creating resources

### DIFF
--- a/pkg/placement/dbsync.go
+++ b/pkg/placement/dbsync.go
@@ -46,7 +46,7 @@ func DbSyncJob(
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName + "-db-sync",
+			Name:      instance.Name + "-db-sync",
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
@@ -60,7 +60,7 @@ func DbSyncJob(
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
-							Name: ServiceName + "-db-sync",
+							Name: instance.Name + "-db-sync",
 							Command: []string{
 								"/bin/bash",
 							},

--- a/pkg/placement/deployment.go
+++ b/pkg/placement/deployment.go
@@ -82,7 +82,7 @@ func Deployment(
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName,
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -99,7 +99,7 @@ func Deployment(
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
-							Name: ServiceName + "-log",
+							Name: instance.Name + "-log",
 							Command: []string{
 								"/usr/bin/dumb-init",
 							},
@@ -122,7 +122,7 @@ func Deployment(
 							LivenessProbe:  livenessProbe,
 						},
 						{
-							Name: ServiceName + "-api",
+							Name: instance.Name + "-api",
 							Command: []string{
 								"/bin/bash",
 							},

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -54,13 +54,13 @@ func CreateNames(placementAPIName types.NamespacedName) Names {
 		// but based on the name of the PlacementAPI CR
 		DBSyncJobName: types.NamespacedName{
 			Namespace: placementAPIName.Namespace,
-			Name:      "placement-db-sync"},
+			Name:      placementAPIName.Name + "-db-sync"},
 		MariaDBDatabaseName: placementAPIName,
 		// FIXME(gibi): the deployment name should not be hardcoded
 		// but based on the name of the PlacementAPI CR
 		DeploymentName: types.NamespacedName{
 			Namespace: placementAPIName.Namespace,
-			Name:      "placement"},
+			Name:      placementAPIName.Name},
 		PublicServiceName: types.NamespacedName{
 			Namespace: placementAPIName.Namespace,
 			Name:      "placement-public"},


### PR DESCRIPTION
Resources created by the placement-operator are
named based on the name of the PlacementAPI CR