### PR TITLE
DNM - Testing FAIL_FIPS_CHECK enabled.

### DIFF
--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,1 +1,2 @@
 export USE_IMAGE_DIGESTS=true
+export FAIL_FIPS_CHECK=true


### PR DESCRIPTION
Testing if setting this flag in repo will result
in build-deploy jobs to fail.