### PR TITLE
Bump to latest mariadb-operator/api

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -137,6 +137,24 @@ rules:
 - apiGroups:
   - mariadb.openstack.org
   resources:
+  - mariadbaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mariadb.openstack.org
+  resources:
+  - mariadbaccounts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - mariadb.openstack.org
+  resources:
   - mariadbdatabases
   verbs:
   - create
@@ -146,6 +164,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - mariadb.openstack.org
+  resources:
+  - mariadbdatabases/finalizers
+  verbs:
+  - update
 - apiGroups:
   - placement.openstack.org
   resources:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240117115727-432678553b37
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240122121228-01dfaafeef46
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240122121228-01dfaafeef46
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240124160436-36095347284f
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240208072109-4447f245e487
 	github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20230602092913-53f380989946
 	go.uber.org/zap v1.26.0
 	k8s.io/api v0.26.13

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024012
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240122121228-01dfaafeef46/go.mod h1:GammFyM5i2OY0lBEAcyEi9Gk46jXFIlD+z+JqBikfoY=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240122121228-01dfaafeef46 h1:7L/STiEV9rcC0uhnPU6FRVox8J3L2d24/z8yK7rQ5Dc=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240122121228-01dfaafeef46/go.mod h1:ni4mvKeubWsTjKmcToJ+hIo7pJipM9hwiUv8qhm1R6Y=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240124160436-36095347284f h1:01HrDX32rjFdvbSOMfz0fBCfxK6Kqthv0BgvimWL7Vc=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240124160436-36095347284f/go.mod h1:gAIo5SMvTTgUomxGC51T3PHIyremhe8xUvz2xpbuCsI=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240208072109-4447f245e487 h1:CyrE+x+AuXjURsiqj+fxOSEbn73hjOvh9g6ZXD4eU9k=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240208072109-4447f245e487/go.mod h1:D4sr4UipU4qjyrcO2mjW8YlSm48AdkY69dloASUbNYE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -25,6 +25,7 @@ import (
 
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	placementv1 "github.com/openstack-k8s-operators/placement-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/placement-operator/pkg/placement"
 )
 
 type Names struct {
@@ -53,14 +54,12 @@ func CreateNames(placementAPIName types.NamespacedName) Names {
 		ConfigMapName: types.NamespacedName{
 			Namespace: placementAPIName.Namespace,
 			Name:      placementAPIName.Name + "-config-data"},
-		// FIXME(gibi): the db sync job name should not be hardcoded
-		// but based on the name of the PlacementAPI CR
 		DBSyncJobName: types.NamespacedName{
 			Namespace: placementAPIName.Namespace,
 			Name:      placementAPIName.Name + "-db-sync"},
-		MariaDBDatabaseName: placementAPIName,
-		// FIXME(gibi): the deployment name should not be hardcoded
-		// but based on the name of the PlacementAPI CR
+		MariaDBDatabaseName: types.NamespacedName{
+			Namespace: placementAPIName.Namespace,
+			Name:      placement.DatabaseName},
 		DeploymentName: types.NamespacedName{
 			Namespace: placementAPIName.Namespace,
 			Name:      placementAPIName.Name},

--- a/tests/functional/placementapi_controller_test.go
+++ b/tests/functional/placementapi_controller_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
-	placement "github.com/openstack-k8s-operators/placement-operator/pkg/placement"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -154,6 +153,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 			placement := GetPlacementAPI(names.PlacementAPIName)
 			Expect(*(placement.Spec.Replicas)).Should(Equal(int32(0)))
@@ -303,12 +303,10 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			db := mariadb.GetMariaDBDatabase(names.MariaDBDatabaseName)
-			// FIXME(gibi): this should be hardcoded to "placement" as this is
-			// the name of the DB schema to be created
-			Expect(db.Spec.Name).To(Equal(placement.DatabaseName))
-			Expect(db.Spec.Secret).To(Equal(SecretName))
+			Expect(db.Spec.Name).To(Equal(names.MariaDBDatabaseName.Name))
 
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 
 			th.ExpectCondition(
 				names.PlacementAPIName,
@@ -331,6 +329,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
 
@@ -355,6 +354,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 
 			keystone.SimulateKeystoneEndpointReady(names.KeystoneEndpointName)
 
@@ -372,6 +372,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 
 			th.ExpectCondition(
 				names.PlacementAPIName,
@@ -404,6 +405,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 
 			th.ExpectCondition(
@@ -442,6 +444,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 			th.SimulateDeploymentReplicaReady(names.DeploymentName)
 
@@ -472,6 +475,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
 			keystone.SimulateKeystoneEndpointReady(names.KeystoneEndpointName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
@@ -528,6 +532,7 @@ var _ = Describe("PlacementAPI controller", func() {
 			)
 
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 			th.SimulateDeploymentReplicaReady(names.DeploymentName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
@@ -599,6 +604,7 @@ var _ = Describe("PlacementAPI controller", func() {
 			)
 
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
 			th.SimulateDeploymentReplicaReady(names.DeploymentName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
@@ -634,6 +640,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
 			keystone.SimulateKeystoneEndpointReady(names.KeystoneEndpointName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
@@ -656,6 +663,8 @@ var _ = Describe("PlacementAPI controller", func() {
 			Expect(keystoneEndpoint.Finalizers).To(ContainElement("PlacementAPI"))
 			db := mariadb.GetMariaDBDatabase(names.MariaDBDatabaseName)
 			Expect(db.Finalizers).To(ContainElement("PlacementAPI"))
+			acc := mariadb.GetMariaDBAccount(names.MariaDBDatabaseName)
+			Expect(acc.Finalizers).To(ContainElement("PlacementAPI"))
 
 			th.DeleteInstance(GetPlacementAPI(names.PlacementAPIName))
 
@@ -665,6 +674,8 @@ var _ = Describe("PlacementAPI controller", func() {
 			Expect(keystoneEndpoint.Finalizers).NotTo(ContainElement("PlacementAPI"))
 			db = mariadb.GetMariaDBDatabase(names.MariaDBDatabaseName)
 			Expect(db.Finalizers).NotTo(ContainElement("PlacementAPI"))
+			acc = mariadb.GetMariaDBAccount(names.MariaDBDatabaseName)
+			Expect(acc.Finalizers).NotTo(ContainElement("PlacementAPI"))
 		})
 
 		It("updates the deployment if configuration changes", func() {
@@ -733,6 +744,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
 			keystone.SimulateKeystoneEndpointReady(names.KeystoneEndpointName)
 			th.SimulateJobSuccess(names.DBSyncJobName)
@@ -798,6 +810,7 @@ var _ = Describe("PlacementAPI reconfiguration", func() {
 				mariadb.CreateDBService(namespace, "openstack", serviceSpec),
 			)
 			mariadb.SimulateMariaDBDatabaseCompleted(names.MariaDBDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(names.MariaDBDatabaseName)
 			keystone.SimulateKeystoneServiceReady(names.KeystoneServiceName)
 			keystone.SimulateKeystoneEndpointReady(names.KeystoneEndpointName)
 			th.SimulateJobSuccess(names.DBSyncJobName)

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -18,7 +18,7 @@ spec:
   secret: osp-secret
   serviceUser: placement
 status:
-  databaseHostname: openstack
+  databaseHostname: openstack.placement-kuttl-tests.svc
   readyCount: 1
   conditions:
   - message: Setup complete

--- a/tests/kuttl/tests/placement_deploy_tls/03-assert.yaml
+++ b/tests/kuttl/tests/placement_deploy_tls/03-assert.yaml
@@ -25,7 +25,7 @@ spec:
         secretName: cert-public-svc
     caBundleSecretName: combined-ca-bundle
 status:
-  databaseHostname: openstack
+  databaseHostname: openstack.placement-kuttl-tests.svc
   readyCount: 1
   conditions:
   - message: Setup complete


### PR DESCRIPTION
Adapt to the new version by:

* adding RBAC rules for MariaDBAccount manipulation
* adding Own(MariaDBAccount) to detect status changes
* separating PlacementAPI CR name from the schema and
  MariaDBDatabase/Account name
* adapting test to simulate MariaDBAccount success
* adapting to new DB hostnames due to the mariadb TLS feature