### PR TITLE
Add missing logic for DefaultConfigOverwrite

### DIFF
--- a/api/bases/placement.openstack.org_placementapis.yaml
+++ b/api/bases/placement.openstack.org_placementapis.yaml
@@ -73,10 +73,8 @@ spec:
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  . TODO: -> implement'
+                description: DefaultConfigOverwrite - interface to overwrite default
+                  config files like policy.yaml.
                 type: object
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource

--- a/api/v1beta1/placementapi_types.go
+++ b/api/v1beta1/placementapi_types.go
@@ -94,9 +94,7 @@ type PlacementAPISpec struct {
 	CustomServiceConfig string `json:"customServiceConfig"`
 
 	// +kubebuilder:validation:Optional
-	// ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
-	// But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
-	// TODO: -> implement
+	// DefaultConfigOverwrite - interface to overwrite default config files like policy.yaml.
 	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/placement.openstack.org_placementapis.yaml
+++ b/config/crd/bases/placement.openstack.org_placementapis.yaml
@@ -73,10 +73,8 @@ spec:
               defaultConfigOverwrite:
                 additionalProperties:
                   type: string
-                description: 'ConfigOverwrite - interface to overwrite default config
-                  files like e.g. policy.json. But can also be used to add additional
-                  files. Those get added to the service config dir in /etc/<service>
-                  . TODO: -> implement'
+                description: DefaultConfigOverwrite - interface to overwrite default
+                  config files like policy.yaml.
                 type: object
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource

--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -1175,7 +1175,6 @@ func (r *PlacementAPIReconciler) ensureDeployment(
 }
 
 // generateServiceConfigMaps - create create configmaps which hold scripts and service configuration
-// TODO add DefaultConfigOverwrite
 func (r *PlacementAPIReconciler) generateServiceConfigMaps(
 	ctx context.Context,
 	h *helper.Helper,
@@ -1195,7 +1194,6 @@ func (r *PlacementAPIReconciler) generateServiceConfigMaps(
 	// customData hold any customization for the service.
 	// custom.conf is going to /etc/<service>/<service>.conf.d
 	// all other files get placed into /etc/<service> to allow overwrite of e.g. policy.json
-	// TODO: make sure custom.conf can not be overwritten
 	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data

--- a/templates/placementapi/config/placement-api-config.json
+++ b/templates/placementapi/config/placement-api-config.json
@@ -40,6 +40,13 @@
             "perm": "0400",
             "optional": true,
             "merge": true
+        },
+        {
+            "source": "/var/lib/openstack/config/policy.yaml",
+            "dest": "/etc/placement/policy.yaml",
+            "owner": "placement",
+            "perm": "0600",
+            "optional": true
         }
     ],
     "permissions": [

--- a/templates/placementapi/config/placement.conf
+++ b/templates/placementapi/config/placement.conf
@@ -24,3 +24,6 @@ www_authenticate_uri = {{ .KeystonePublicURL }}
 auth_url = {{ .KeystoneInternalURL }}
 auth_type = password
 interface = internal
+
+[oslo_policy]
+policy_file=/etc/placement/policy.yaml


### PR DESCRIPTION
We only want to support the policy.yaml file passthrough for PlacementAPI

The kolla config files are modified to move the supported files in place.

Implements: [OSPRH-2503](https://issues.redhat.com//browse/OSPRH-2503)