### PR TITLE
[renovate]Remove golang constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,6 @@
   "extends": [
     "github>openstack-k8s-operators/renovate-config:default.json5"
   ],
-  "constraints": {
-    "go": "1.19"
-  },
   "packageRules": [
     {
       "matchPackageNames": ["github.com/openstack-k8s-operators/placement-operator/api"],


### PR DESCRIPTION
The shared global config already has a golang 1.20 constraint