### PR TITLE
migrate from databaseUsername to databaseAccount

### DIFF
--- a/api/bases/placement.openstack.org_placementapis.yaml
+++ b/api/bases/placement.openstack.org_placementapis.yaml
@@ -59,16 +59,15 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: placement
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseInstance:
                 description: MariaDB instance name Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB Might
                   not be required in future
-                type: string
-              databaseUser:
-                default: placement
-                description: 'DatabaseUser - optional username used for placement
-                  DB, defaults to placement TODO: -> implement needs work in mariadb-operator,
-                  right now only placement'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -264,16 +263,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: PlacementDatabasePassword
                   service: PlacementPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: PlacementDatabasePassword
-                    description: 'Database - Selector to get the Database user password
-                      from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: PlacementPassword
                     description: Service - Selector to get the service user password
@@ -343,7 +336,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  placement PlacementDatabasePassword, PlacementPassword
+                  placement PlacementPassword
                 type: string
               serviceUser:
                 default: placement

--- a/api/v1beta1/placementapi_types.go
+++ b/api/v1beta1/placementapi_types.go
@@ -54,9 +54,8 @@ type PlacementAPISpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=placement
-	// DatabaseUser - optional username used for placement DB, defaults to placement
-	// TODO: -> implement needs work in mariadb-operator, right now only placement
-	DatabaseUser string `json:"databaseUser"`
+	// DatabaseAccount - name of MariaDBAccount which will be used to connect.
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Required
 	// PlacementAPI Container Image URL (will be set to environmental default if empty)
@@ -70,11 +69,11 @@ type PlacementAPISpec struct {
 	Replicas *int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Required
-	// Secret containing OpenStack password information for placement PlacementDatabasePassword, PlacementPassword
+	// Secret containing OpenStack password information for placement PlacementPassword
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: PlacementDatabasePassword, service: PlacementPassword}
+	// +kubebuilder:default={service: PlacementPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
@@ -125,11 +124,6 @@ type APIOverrideSpec struct {
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret
 type PasswordSelector struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="PlacementDatabasePassword"
-	// Database - Selector to get the Database user password from the Secret
-	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="PlacementPassword"
 	// Service - Selector to get the service user password from the Secret

--- a/config/crd/bases/placement.openstack.org_placementapis.yaml
+++ b/config/crd/bases/placement.openstack.org_placementapis.yaml
@@ -59,16 +59,15 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: placement
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseInstance:
                 description: MariaDB instance name Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB Might
                   not be required in future
-                type: string
-              databaseUser:
-                default: placement
-                description: 'DatabaseUser - optional username used for placement
-                  DB, defaults to placement TODO: -> implement needs work in mariadb-operator,
-                  right now only placement'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -264,16 +263,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: PlacementDatabasePassword
                   service: PlacementPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: PlacementDatabasePassword
-                    description: 'Database - Selector to get the Database user password
-                      from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: PlacementPassword
                     description: Service - Selector to get the service user password
@@ -343,7 +336,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  placement PlacementDatabasePassword, PlacementPassword
+                  placement PlacementPassword
                 type: string
               serviceUser:
                 default: placement

--- a/config/manifests/bases/placement-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/placement-operator.clusterserviceversion.yaml
@@ -18,6 +18,10 @@ spec:
       displayName: Placement API
       kind: PlacementAPI
       name: placementapis.placement.openstack.org
+      specDescriptors:
+      - description: TLS - Parameters related to the TLS
+        displayName: TLS
+        path: tls
       version: v1beta1
   description: Placement Operator
   displayName: Placement Operator

--- a/config/samples/placement_v1beta1_placementapi.yaml
+++ b/config/samples/placement_v1beta1_placementapi.yaml
@@ -8,7 +8,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: placement
+  databaseAccount: placement
   preserveJobs: false
   replicas: 1
   secret: placement-secret

--- a/config/samples/placement_v1beta1_placementtls.yaml
+++ b/config/samples/placement_v1beta1_placementtls.yaml
@@ -8,7 +8,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: placement
+  databaseAccount: placement
   preserveJobs: false
   replicas: 1
   secret: placement-secret

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240226160457-b1b853eb4600
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240229121803-169ced56d56e
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240229121803-169ced56d56e
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
 	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240216174613-3d349f26e681
 	go.uber.org/zap v1.27.0
 	k8s.io/api v0.28.7

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024022
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240229121803-169ced56d56e/go.mod h1:fvCDr4wd7Oy2rIunTzpGoMKWXHk2pQYaF3tJBFLELpM=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240229121803-169ced56d56e h1:rbVGqqtxuJy/RvSVERJG6ZLahbJguOZzPRUpGNT1k38=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240229121803-169ced56d56e/go.mod h1:/ZkLOznBDxjChwIFFK3xg3EZ13WmZPP4ehu5wWy1T8E=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093 h1:gmm2o5bVYIeuAVHp7WsDIpQc8vh+/9tUUYY4Wfyus/o=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -34,6 +34,7 @@ type Names struct {
 	ConfigMapName          types.NamespacedName
 	DBSyncJobName          types.NamespacedName
 	MariaDBDatabaseName    types.NamespacedName
+	MariaDBAccount         types.NamespacedName
 	DeploymentName         types.NamespacedName
 	PublicServiceName      types.NamespacedName
 	InternalServiceName    types.NamespacedName
@@ -60,6 +61,9 @@ func CreateNames(placementAPIName types.NamespacedName) Names {
 		MariaDBDatabaseName: types.NamespacedName{
 			Namespace: placementAPIName.Namespace,
 			Name:      placement.DatabaseName},
+		MariaDBAccount: types.NamespacedName{
+			Namespace: placementAPIName.Namespace,
+			Name:      AccountName},
 		DeploymentName: types.NamespacedName{
 			Namespace: placementAPIName.Namespace,
 			Name:      placementAPIName.Name},
@@ -100,6 +104,7 @@ func GetDefaultPlacementAPISpec() map[string]interface{} {
 	return map[string]interface{}{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
+		"databaseAccount":  AccountName,
 	}
 }
 
@@ -108,6 +113,7 @@ func GetTLSPlacementAPISpec(names Names) map[string]interface{} {
 		"databaseInstance": "openstack",
 		"replicas":         1,
 		"secret":           SecretName,
+		"databaseAccount":  AccountName,
 		"tls": map[string]interface{}{
 			"api": map[string]interface{}{
 				"internal": map[string]interface{}{

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -76,6 +76,8 @@ const (
 
 	SecretName = "test-osp-secret"
 
+	AccountName = "test-placement-account"
+
 	PublicCertSecretName = "public-tls-certs"
 
 	InternalCertSecretName = "internal-tls-certs"

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -9,9 +9,8 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: placement
+  databaseAccount: placement
   passwordSelectors:
-    database: PlacementDatabasePassword
     service: PlacementPassword
   preserveJobs: false
   replicas: 1
@@ -53,6 +52,10 @@ status:
     reason: Ready
     status: "True"
     type: KeystoneServiceReady
+  - message: MariaDBAccount creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
   - message: NetworkAttachments completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/placement_deploy_tls/03-assert.yaml
+++ b/tests/kuttl/tests/placement_deploy_tls/03-assert.yaml
@@ -9,9 +9,8 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: placement
+  databaseAccount: placement
   passwordSelectors:
-    database: PlacementDatabasePassword
     service: PlacementPassword
   preserveJobs: false
   replicas: 1
@@ -60,6 +59,10 @@ status:
     reason: Ready
     status: "True"
     type: KeystoneServiceReady
+  - message: MariaDBAccount creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
   - message: NetworkAttachments completed
     reason: Ready
     status: "True"


### PR DESCRIPTION
This moves placement to fully use MariaDBAccount based on the dev work being done for mariadb-operator:

https://github.com/openstack-k8s-operators/mariadb-operator/pull/184/files

Lead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x]  all databaseUser replaced with databaseAccount inside of all XYZ_types.go
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [x] MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them
14. [x] Use configsecrets for database URLs; remove from job hash  - already was like that
15. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed 


