### PR TITLE
use Eventually in RunURLAssertSuite test

### DIFF
--- a/tests/functional/placementapi_controller_test.go
+++ b/tests/functional/placementapi_controller_test.go
@@ -919,13 +919,15 @@ var _ = Describe("PlacementAPI controller", func() {
 	mariadb_suite.RunBasicSuite()
 
 	mariadb_suite.RunURLAssertSuite(func(accountName types.NamespacedName, username string, password string) {
-		cm := th.GetSecret(names.ConfigMapName)
+		Eventually(func(g Gomega) {
+			cm := th.GetSecret(names.ConfigMapName)
 
-		conf := cm.Data["placement.conf"]
+			conf := cm.Data["placement.conf"]
 
-		Expect(string(conf)).Should(
-			ContainSubstring(fmt.Sprintf("connection = mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/placement?read_default_file=/etc/my.cnf",
-				username, password, namespace)))
+			g.Expect(string(conf)).Should(
+				ContainSubstring(fmt.Sprintf("connection = mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/placement?read_default_file=/etc/my.cnf",
+					username, password, namespace)))
+		}, timeout, interval).Should(Succeed())
 
 	})
 


### PR DESCRIPTION
The RunURLAssertSuite harness currently waits on finalizers added to MariaDBAccount as an indication when it's safe to test that the new URL is present in the config.  however, in [1] we are discussing removing the use of finalizers here so that this harness can be generalized to more kinds of controllers. as such, if the assertion here uses Eventually, it becomes compatible with this change, as the waiting for the condition is implemented directly here.

[1]
https://github.com/openstack-k8s-operators/mariadb-operator/pull/205#pullrequestreview-1916137443