### PR TITLE
Correct ValidateUpdate for PlacementSpecCore

### DIFF
--- a/api/v1beta1/placementapi_webhook.go
+++ b/api/v1beta1/placementapi_webhook.go
@@ -137,7 +137,7 @@ func (r PlacementAPISpecCore) ValidateCreate(basePath *field.Path) field.ErrorLi
 	return ValidateDefaultConfigOverwrite(basePath, r.DefaultConfigOverwrite)
 }
 
-func (r PlacementAPISpecCore) ValidateUpdate(old PlacementAPISpec, basePath *field.Path) field.ErrorList {
+func (r PlacementAPISpecCore) ValidateUpdate(old PlacementAPISpecCore, basePath *field.Path) field.ErrorList {
 	return ValidateDefaultConfigOverwrite(basePath, r.DefaultConfigOverwrite)
 }
 


### PR DESCRIPTION
Updates the function so that the type of the "old" and reciever are the same.