### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["--verbose"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pkg/placement/deployment.go
+++ b/pkg/placement/deployment.go
@@ -16,12 +16,9 @@ limitations under the License.
 package placement
 
 import (
-	"context"
-
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	affinity "github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
 	env "github.com/openstack-k8s-operators/lib-common/modules/common/env"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 
@@ -36,8 +33,6 @@ import (
 
 // Deployment func
 func Deployment(
-	ctx context.Context,
-	helper *helper.Helper,
 	instance *placementv1.PlacementAPI,
 	configHash string,
 	labels map[string]string,

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package functional_test
 
 import (
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/functional/placementapi_controller_test.go
+++ b/tests/functional/placementapi_controller_test.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/placement-operator/pkg/placement"
@@ -485,7 +487,7 @@ var _ = Describe("PlacementAPI controller", func() {
 			Expect(int(*deployment.Spec.Replicas)).To(Equal(1))
 			Expect(deployment.Spec.Selector.MatchLabels).To(Equal(map[string]string{"service": "placement", "owner": names.PlacementAPIName.Name}))
 			Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal(names.ServiceAccountName.Name))
-			Expect(len(deployment.Spec.Template.Spec.Containers)).To(Equal(2))
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(2))
 
 			th.SimulateDeploymentReplicaReady(names.DeploymentName)
 
@@ -858,7 +860,7 @@ var _ = Describe("PlacementAPI controller", func() {
 	// that exercise standard account create / update patterns that should be
 	// common to all controllers that ensure MariaDBAccount CRs.
 
-	mariadb_suite := &mariadb_test.MariaDBTestHarness{
+	mariadbSuite := &mariadb_test.MariaDBTestHarness{
 		PopulateHarness: func(harness *mariadb_test.MariaDBTestHarness) {
 			harness.Setup(
 				"Placement",
@@ -916,9 +918,9 @@ var _ = Describe("PlacementAPI controller", func() {
 		},
 	}
 
-	mariadb_suite.RunBasicSuite()
+	mariadbSuite.RunBasicSuite()
 
-	mariadb_suite.RunURLAssertSuite(func(accountName types.NamespacedName, username string, password string) {
+	mariadbSuite.RunURLAssertSuite(func(accountName types.NamespacedName, username string, password string) {
 		Eventually(func(g Gomega) {
 			cm := th.GetSecret(names.ConfigMapName)
 
@@ -931,7 +933,7 @@ var _ = Describe("PlacementAPI controller", func() {
 
 	})
 
-	mariadb_suite.RunConfigHashSuite(func() string {
+	mariadbSuite.RunConfigHashSuite(func() string {
 		deployment := th.GetDeployment(names.DeploymentName)
 		return GetEnvVarValue(deployment.Spec.Template.Spec.Containers[0].Env, "CONFIG_HASH", "")
 	})

--- a/tests/functional/placementapi_webhook_test.go
+++ b/tests/functional/placementapi_webhook_test.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"os"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,11 +32,11 @@ import (
 
 var _ = Describe("PlacementAPI Webhook", func() {
 
-	var placementApiName types.NamespacedName
+	var placementAPIName types.NamespacedName
 
 	BeforeEach(func() {
 
-		placementApiName = types.NamespacedName{
+		placementAPIName = types.NamespacedName{
 			Name:      "placement",
 			Namespace: namespace,
 		}
@@ -47,11 +47,11 @@ var _ = Describe("PlacementAPI Webhook", func() {
 
 	When("A PlacementAPI instance is created without container images", func() {
 		BeforeEach(func() {
-			DeferCleanup(th.DeleteInstance, CreatePlacementAPI(placementApiName, GetDefaultPlacementAPISpec()))
+			DeferCleanup(th.DeleteInstance, CreatePlacementAPI(placementAPIName, GetDefaultPlacementAPISpec()))
 		})
 
 		It("should have the defaults initialized by webhook", func() {
-			PlacementAPI := GetPlacementAPI(placementApiName)
+			PlacementAPI := GetPlacementAPI(placementAPIName)
 			Expect(PlacementAPI.Spec.ContainerImage).Should(Equal(
 				placementv1.PlacementAPIContainerImage,
 			))
@@ -60,13 +60,13 @@ var _ = Describe("PlacementAPI Webhook", func() {
 
 	When("A PlacementAPI instance is created with container images", func() {
 		BeforeEach(func() {
-			placementApiSpec := GetDefaultPlacementAPISpec()
-			placementApiSpec["containerImage"] = "api-container-image"
-			DeferCleanup(th.DeleteInstance, CreatePlacementAPI(placementApiName, placementApiSpec))
+			placementAPISpec := GetDefaultPlacementAPISpec()
+			placementAPISpec["containerImage"] = "api-container-image"
+			DeferCleanup(th.DeleteInstance, CreatePlacementAPI(placementAPIName, placementAPISpec))
 		})
 
 		It("should use the given values", func() {
-			PlacementAPI := GetPlacementAPI(placementApiName)
+			PlacementAPI := GetPlacementAPI(placementAPIName)
 			Expect(PlacementAPI.Spec.ContainerImage).Should(Equal(
 				"api-container-image",
 			))
@@ -83,8 +83,8 @@ var _ = Describe("PlacementAPI Webhook", func() {
 			"apiVersion": "placement.openstack.org/v1beta1",
 			"kind":       "PlacementAPI",
 			"metadata": map[string]interface{}{
-				"name":      placementApiName.Name,
-				"namespace": placementApiName.Namespace,
+				"name":      placementAPIName.Name,
+				"namespace": placementAPIName.Namespace,
 			},
 			"spec": spec,
 		}

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"


### PR DESCRIPTION
This needed the following adjustments:

* removed unused functions and function parameters
* rename variables to follow style
* ignore revive dot-imports rule as ginkgo and gomega
