### PR TITLE
Bump Placement probe timeouts

### DIFF
--- a/pkg/placement/deployment.go
+++ b/pkg/placement/deployment.go
@@ -40,14 +40,14 @@ func Deployment(
 ) (*appsv1.Deployment, error) {
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
-		TimeoutSeconds:      5,
-		PeriodSeconds:       3,
-		InitialDelaySeconds: 3,
+		TimeoutSeconds:      30,
+		PeriodSeconds:       30,
+		InitialDelaySeconds: 5,
 	}
 	readinessProbe := &corev1.Probe{
 		// TODO might need tuning
-		TimeoutSeconds:      5,
-		PeriodSeconds:       5,
+		TimeoutSeconds:      30,
+		PeriodSeconds:       30,
 		InitialDelaySeconds: 5,
 	}
 

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -121,10 +121,10 @@ spec:
             path: /
             port: 8778
             scheme: HTTP
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 30
         name: placement-log
         readinessProbe:
           failureThreshold: 3
@@ -133,9 +133,9 @@ spec:
             port: 8778
             scheme: HTTP
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 30
         resources: {}
         securityContext:
           runAsUser: 42482
@@ -165,10 +165,10 @@ spec:
             path: /
             port: 8778
             scheme: HTTP
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 30
         name: placement-api
         readinessProbe:
           failureThreshold: 3
@@ -177,9 +177,9 @@ spec:
             port: 8778
             scheme: HTTP
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 30
         resources: {}
       restartPolicy: Always
       securityContext: {}

--- a/tests/kuttl/tests/placement_deploy_tls/03-assert.yaml
+++ b/tests/kuttl/tests/placement_deploy_tls/03-assert.yaml
@@ -128,10 +128,10 @@ spec:
             path: /
             port: 8778
             scheme: HTTPS
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 30
         name: placement-log
         readinessProbe:
           failureThreshold: 3
@@ -140,9 +140,9 @@ spec:
             port: 8778
             scheme: HTTPS
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 30
         resources: {}
         securityContext:
           runAsUser: 42482
@@ -192,10 +192,10 @@ spec:
             path: /
             port: 8778
             scheme: HTTPS
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 30
         name: placement-api
         readinessProbe:
           failureThreshold: 3
@@ -204,9 +204,9 @@ spec:
             port: 8778
             scheme: HTTPS
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 30
         resources: {}
       restartPolicy: Always
       securityContext: {}


### PR DESCRIPTION
When deploying locally in crc placement can crashloop
indefintly because the readiness and liveness probe
were set to strictly.

The nova-operator relaxed the probes becuase of tempest failures
in openstack-k8s-operators/nova-operator#381

This change updates the placement values to match.
