### PR TITLE
[pre-commit]Run make bundle 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
       entry: make
       args: ['operator-lint']
       pass_filenames: false
+    - id: make-bundle
+      name: make-bundle
+      language: system
+      entry: make
+      args: ['bundle', 'VERSION=0.0.1']
+      pass_filenames: false
 
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1

--- a/config/manifests/bases/placement-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/placement-operator.clusterserviceversion.yaml
@@ -4,8 +4,8 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
     operatorframework.io/suggested-namespace: openstack
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone


### PR DESCRIPTION
We noticed that make bundle can re-generate some of the manifests
causing local diffs in later stages. So to catch such re-generation
needs lets run it in pre-commit.
