### PR TITLE
Revert "Wait for DB writes to propagate (causality checks)"

### DIFF
--- a/templates/placementapi/config/placement.conf
+++ b/templates/placementapi/config/placement.conf
@@ -11,11 +11,6 @@ debug = true
 [placement_database]
 connection = {{ .DatabaseConnection }}
 
-# Wait for writes to complete when doing a read.
-# Relevant for multi-master galera deployments
-# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 1
-
 [api]
 auth_strategy = keystone
 

--- a/tests/functional/placementapi_controller_test.go
+++ b/tests/functional/placementapi_controller_test.go
@@ -333,7 +333,6 @@ var _ = Describe("PlacementAPI controller", func() {
 			Expect(string(conf)).Should(
 				ContainSubstring(fmt.Sprintf("connection = mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/placement?read_default_file=/etc/my.cnf",
 					mariadbAccount.Spec.UserName, mariadbSecret.Data[mariadbv1.DatabasePasswordSelector], namespace)))
-			Expect(string(conf)).Should(ContainSubstring("mysql_wsrep_sync_wait = 1"))
 
 			custom := cm.Data["custom.conf"]
 			Expect(custom).Should(ContainSubstring("foo = bar"))


### PR DESCRIPTION
This reverts commit a5b0bf43b21f495db52eac58c44e52261744605c.

The https://github.com/openstack-k8s-operators/mariadb-operator/pull/229
switched the mariadb-operator to Active/Passive mode instead of
multimaster. This means we don't need to force synchronization from the
client config any more.

Related: [OSPRH-7405](https://issues.redhat.com//browse/OSPRH-7405)