### PR TITLE
Added a parameter 'apiTimeout' to allow customization

### DIFF
--- a/api/bases/placement.openstack.org_placementapis.yaml
+++ b/api/bases/placement.openstack.org_placementapis.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: PlacementAPISpec defines the desired state of PlacementAPI
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for HAProxy, Apache
+                minimum: 10
+                type: integer
               containerImage:
                 description: PlacementAPI Container Image URL (will be set to environmental
                   default if empty)

--- a/api/v1beta1/placementapi_types.go
+++ b/api/v1beta1/placementapi_types.go
@@ -51,6 +51,12 @@ type PlacementAPISpec struct {
 // PlacementAPISpecCore -
 type PlacementAPISpecCore struct {
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for HAProxy, Apache
+	APITimeout int `json:"apiTimeout"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=placement
 	// ServiceUser - optional username used for this service to register in keystone
 	ServiceUser string `json:"serviceUser"`

--- a/config/crd/bases/placement.openstack.org_placementapis.yaml
+++ b/config/crd/bases/placement.openstack.org_placementapis.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: PlacementAPISpec defines the desired state of PlacementAPI
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for HAProxy, Apache
+                minimum: 10
+                type: integer
               containerImage:
                 description: PlacementAPI Container Image URL (will be set to environmental
                   default if empty)

--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -1265,6 +1265,7 @@ func (r *PlacementAPIReconciler) generateServiceConfigMaps(
 		httpdVhostConfig[endpt.String()] = endptConfig
 	}
 	templateParameters["VHosts"] = httpdVhostConfig
+	templateParameters["TimeOut"] = instance.Spec.APITimeout
 
 	extraTemplates := map[string]string{
 		"placement.conf": "placementapi/config/placement.conf",

--- a/templates/placementapi/config/httpd.conf
+++ b/templates/placementapi/config/httpd.conf
@@ -35,6 +35,7 @@ CustomLog /dev/stdout proxy env=forwarded
     ErrorLogFormat "%M"
   </IfVersion>
   ServerName {{ $vhost.ServerName }}
+  TimeOut {{ $.TimeOut }}
 
   ## Vhost docroot
   ErrorLog /dev/stdout

--- a/tests/functional/placementapi_controller_test.go
+++ b/tests/functional/placementapi_controller_test.go
@@ -344,6 +344,9 @@ var _ = Describe("PlacementAPI controller", func() {
 			myCnf := cm.Data["my.cnf"]
 			Expect(myCnf).To(
 				ContainSubstring("[client]\nssl=0"))
+			configData := cm.Data["httpd.conf"]
+			Expect(configData).Should(
+				ContainSubstring("TimeOut 60"))
 		})
 
 		It("creates service account, role and rolebindig", func() {


### PR DESCRIPTION
to the Apache timeout.

The default is set to 60s which we do set for
HAProxy timeouts currently.

To be able to change the HAProxy value based on the apiTimeout with any update (and not just the first time) the code adds a custom annotation "api.placement.openstack.org/timeout" with the value that was initially set, this way flags it as being set by the placement-operator.

Timeout is global for both api and metadata and they are set from placement lvl

There will be follow up patch in openstack-operator to utilize the method 'SetDefaultRouteAnnotations' to set these default route annotations in openstack-operator

resolve: https://issues.redhat.com/browse/OSPRH-10962