### PR TITLE
Improve error handling

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,5 +7,8 @@ linters:
     - ginkgolinter
     - gofmt
     - govet
+    - gosec
+    - errname
+    - err113
 run:
   timeout: 5m

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -79,11 +79,11 @@ const (
 
 	AccountName = "test-placement-account"
 
-	PublicCertSecretName = "public-tls-certs"
+	PublicCertSecretName = "public-tls-certs" // #nosec G101
 
-	InternalCertSecretName = "internal-tls-certs"
+	InternalCertSecretName = "internal-tls-certs" // #nosec G101
 
-	CABundleSecretName = "combined-ca-bundle"
+	CABundleSecretName = "combined-ca-bundle" // #nosec G101
 
 	interval = time.Millisecond * 200
 )
@@ -201,7 +201,7 @@ var _ = BeforeSuite(func() {
 	dialer := &net.Dialer{Timeout: time.Duration(10) * time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
-		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true}) // #nosec G402
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
To follow best practices for error and exception handling in Go and to prevent regressions, err113 and gosec checks in golang-ci-linter are now enabled. Errors now use predefined messages for status updates.
Resolve:  https://issues.redhat.com/browse/OSPRH-9063


Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1306