### PR TITLE
add basic zuul jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,4 +1,62 @@
 ---
+- job:
+    name: placement-operator-kuttl
+    parent: cifmw-multinode-kuttl-operator-target
+    dependencies: ["openstack-meta-content-provider"]
+    roles:
+      - zuul: github.com/openstack-k8s-operators/ci-framework
+    post-run:
+      - ci/playbooks/collect-logs.yaml
+    vars:
+      collection_namespace_override: "placement-kuttl-default"
+      operator_name: placement-operator
+      placement_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/placement-operator"
+      zuul_log_collection: true
+      placement_hook: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/placement-operator'].src_dir }}/ci/placement-operator-kuttl/deploy_webhooks.yaml"
+      pre_kuttl_from_operator:
+        - name: 70 Create placement webhooks
+          type: playbook
+          source: "{{ placement_hook }}"
+          extra_vars:
+            placement_catalog_image: "{{ content_provider_registry_ip }}:5001/openstack-k8s-operators/placement-operator-index:{{ zuul.patchset }}"
+    extra-vars:
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            range: 192.168.122.0/24
+            mtu: 1500
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+
+- job:
+    name: placement-operator-tempest-multinode
+    parent: nova-operator-tempest-multinode
+    vars:
+      cifmw_test_operator_tempest_include_list: |
+        '(?!.*\[.*\bslow\b.*\])(^tempest\.api)'
+        '(?!.*\[.*\bslow\b.*\])(^tempest\.scenario)|(^tempest\.serial_tests)'
 
 - project:
     name: openstack-k8s-operators/placement-operator
@@ -6,4 +64,6 @@
     merge-mode: rebase
     github-check:
       jobs:
-        - noop
+        - openstack-meta-content-provider
+        - placement-operator-kuttl
+        - placement-operator-tempest-multinode

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ DEFAULT_IMG ?= quay.io/openstack-k8s-operators/placement-operator:latest
 IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29
+CATALOG_IMAGE ?= quay.io/openstack-k8s-operators/placement-operator-index:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -384,3 +385,10 @@ PHONY: crd-schema-check
 crd-schema-check: manifests
 	INSTALL_DIR=$(LOCALBIN) CRD_SCHEMA_CHECKER_VERSION=$(CRD_SCHEMA_CHECKER_VERSION) hack/build-crd-schema-checker.sh
 	INSTALL_DIR=$(LOCALBIN) BASE_REF="$${PULL_BASE_SHA:-$(BRANCH)}" hack/crd-schema-checker.sh
+
+.PHONY: run_with_olm
+run_with_olm: export CATALOG_IMG=${CATALOG_IMAGE}
+run_with_olm: ## Install placement operator via olm
+	bash ci/olm.sh
+	oc apply -f ci/olm.yaml
+	timeout 300s bash -c "while ! (oc get csv -n openstack-operators -l operators.coreos.com/placement-operator.openstack-operators -o jsonpath='{.items[*].status.phase}' | grep Succeeded); do sleep 1; done"

--- a/ci/olm.sh
+++ b/ci/olm.sh
@@ -1,0 +1,36 @@
+cat > ci/olm.yaml <<EOF_CAT
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: openstack-operators
+    labels:
+      pod-security.kubernetes.io/enforce: privileged
+      security.openshift.io/scc.podSecurityLabelSync: "false"
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: placement-operator-index
+  namespace: openstack-operators
+spec:
+  image: ${CATALOG_IMG}
+  sourceType: grpc
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openstack
+  namespace: openstack-operators
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: placement-operator
+  namespace: openstack-operators
+spec:
+  name: placement-operator
+  channel: alpha
+  source: placement-operator-index
+  sourceNamespace: openstack-operators
+EOF_CAT

--- a/ci/placement-operator-kuttl/deploy_webhooks.yaml
+++ b/ci/placement-operator-kuttl/deploy_webhooks.yaml
@@ -1,0 +1,17 @@
+- name: Create custom service
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  gather_facts: false
+  tasks:
+    - name: Scale down deployment
+      ansible.builtin.shell: |
+        oc patch csv -n openstack-operators openstack-operator.v0.0.1 --type json -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", "value": "0"}]"
+    - name: Install Placement Operator
+      cifmw.general.ci_script:
+        output_dir: "{{ cifmw_basedir }}/artifacts"
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/placement-operator"
+        script: make run_with_olm
+        extra_args:
+          CATALOG_IMAGE: "{{ placement_catalog_image }}"

--- a/ci/playbooks/collect-logs.yaml
+++ b/ci/playbooks/collect-logs.yaml
@@ -1,0 +1,77 @@
+---
+- hosts: controller
+  name: Collect logs on the controller
+  gather_facts: false
+  vars:
+    collection_namespace: "{{ collection_namespace_override | default('openstack') }}"
+  tasks:
+    - name: Create log dir
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs/controller"
+        state: directory
+        mode: "0755"
+    - name: Collect general openshift cr info
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+      ansible.builtin.shell: |
+        source ~/.bashrc
+        collection_namespace_dir="{{ ansible_user_dir }}/zuul-output/logs/controller/{{collection_namespace}}"
+        mkdir ${collection_namespace_dir}
+        pushd ${collection_namespace_dir}
+          oc get -n {{collection_namespace}} secrets > all_secrets.txt
+          oc get -n {{collection_namespace}} pv > all_pv.txt
+          oc get -n {{collection_namespace}} events > oc_events.txt
+          oc get -n {{collection_namespace}} routes > oc_routes.txt
+          oc get -n {{collection_namespace}} all > oc_all.txt
+        popd
+        pod_dir="${collection_namespace_dir}/pods"
+        mkdir ${pod_dir}
+        pushd ${pod_dir}
+          all_pods=$(oc get -n {{collection_namespace}} pods | awk '{print $1}' | awk -F '.' '{print $1}')
+          for pod in $all_pods; do
+            echo $pod
+            oc logs -n {{collection_namespace}} pod/${pod} > ${pod}-logs.txt
+            oc get  -n {{collection_namespace}} -o yaml pod/${pod} > ${pod}.yaml
+            oc describe -n {{collection_namespace}} pod/${pod} > ${pod}-describe.txt
+          done
+        popd
+        crd_logs="${collection_namespace_dir}/crd"
+        mkdir ${crd_logs}
+        pushd ${crd_logs}
+          all_crds=$(oc get crd | grep openstack | awk '{print $1}' | awk -F '.' '{print $1}')
+          for cr in $all_crds; do
+            echo $crd
+            oc get -n {{collection_namespace}} -o yaml $cr > ${cr}.yaml
+            oc describe -n {{collection_namespace}} $cr > ${cr}-describe.txt
+          done
+        popd
+        openstack_operator_namespace_dir="{{ ansible_user_dir }}/zuul-output/logs/controller/openstack-operators"
+        mkdir ${openstack_operator_namespace_dir}
+        csv_logs="${openstack_operator_namespace_dir}/csv"
+        mkdir ${csv_logs}
+        pushd ${csv_logs}
+          all_csv=$(oc get -n openstack-operators csv | awk '{print $1}')
+          for csv in $all_csv; do
+            echo $crd
+            oc get -n openstack-operators -o yaml csv/${csv} > ${csv}.yaml
+            oc describe -n openstack-operators csv/${csv} > ${csv}-describe.txt
+          done
+        popd
+        pod_dir="${openstack_operator_namespace_dir}/pods"
+        mkdir ${pod_dir}
+        pushd ${pod_dir}
+          all_pods=$(oc get -n openstack-operators pods | awk '{print $1}' | awk -F '.' '{print $1}')
+          for pod in $all_pods; do
+            echo $pod
+            oc logs -n openstack-operators pod/${pod} > ${pod}-logs.txt
+            oc get  -n openstack-operators -o yaml pod/${pod} > ${pod}.yaml
+            oc describe -n openstack-operators pod/${pod} > ${pod}-describe.txt
+          done
+        popd
+      args:
+        chdir: "{{ ansible_user_dir }}/zuul-output/logs/controller"
+      changed_when: true
+      ignore_errors: true
+      tags:
+        - skip_ansible_lint


### PR DESCRIPTION
This change adds 2 new zuul jobs
first we leaverge the common zuul kuttl job that is designed
to run kuttl form in tree. to enable that i have ported
the webhook install fix form nova-operator

second the nova-operator-tempest-multinode job
is used as a base for a placemnet version to provide tempest
coverage on placement operator changes.
