### PR TITLE
add zuul noop jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,9 @@
+---
+
+- project:
+    name: openstack-k8s-operators/placement-operator
+    default-branch: main
+    merge-mode: rebase
+    github-check:
+      jobs:
+        - noop


### PR DESCRIPTION
add safe jobs we know can't fail so that we can use
zuuls speculitve merge feature to add complex ones
later.
