### PR TITLE
remove placeholder design section from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,6 @@ either by DNS or via /etc/hosts:
 +--------------+-----------+------------------------------------------------------------------+
 ```
 
-# Design
-*TBD*
-
 # Testing
 The repository uses [EnvTest](https://book.kubebuilder.io/reference/envtest.html) to validate the operator in a self
 contained environment.


### PR DESCRIPTION
This is a trivial change to remove the TBD design
section form the readme file.
