### PR TITLE
Fix go.mod checksum mismatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250406092234-10f5f7e5b5a9
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250408123225-0d9e9b82c41b
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250402133843-5a4c5f4fb4f1
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.0
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20250415060817-dc849adfa27e
 	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240216174613-3d349f26e681
 	go.uber.org/zap v1.27.0
 	k8s.io/api v0.29.15

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.202504021
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20250402133843-5a4c5f4fb4f1/go.mod h1:5+v92XC/PRATIiBrhNLEpJ+T4R9JpxBCgRP6QvbfwgE=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250402133843-5a4c5f4fb4f1 h1:Tdq+6lI4yPMjEwTMyw4+EGMuyEA9Gql07kDBBVm50bI=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20250402133843-5a4c5f4fb4f1/go.mod h1:oKvVb28i6wwBR5uQO2B2KMzZnCFTPCUCj31c5Zvz2lo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.6.0 h1:dcSfC4ufrJve8A7jimLL1TtVVBsyGNrXpHCh2m2xDs0=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.6.0/go.mod h1:uW5rfxoe1Cj/4UJgCnhS875o0/jIwjjx078qY16cu0k=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20250415060817-dc849adfa27e h1:42PsCCv8ebk2tCw/ZiWsJJMhI4C3fmdUaatKSOJ0GXk=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20250415060817-dc849adfa27e/go.mod h1:ZgHSxZSgpgHg1FhKPnBm/cqxAJbVFbKiBkqQoRohn3Q=
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20241017142550-a3524acedd49 h1:/7SnnHfGCH/dwuZFNUx54zw4cnwv2w6hjONq16aoowM=
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20241017142550-a3524acedd49/go.mod h1:6Mq2N/KtNFW20L+PQC5qkeK8R8UGadmGBXL8HDY6lcg=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This patch fixes the following error:

```
verifying github.com/openstack-k8s-operators/mariadb-operator/api@v0.6.0: checksum mismatch
  downloaded: h1:fzGnHYRuBAehQTbiPVyjoNtC2eTd7mLVE3+52PUoQsI=
  go.sum:     h1:dcSfC4ufrJve8A7jimLL1TtVVBsyGNrXpHCh2m2xDs0=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum. The bits may have been replaced on the origin server, or an attacker may have intercepted the download attempt.
```

that prevents bumping the existing dependencies and blocks other patches.