### PR TITLE
Use ReaderFailOnMissingInformer for cache options

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	cache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -97,6 +98,7 @@ func main() {
 			BindAddress: metricsAddr,
 		},
 		HealthProbeBindAddress: probeAddr,
+		Cache:                  cache.Options{ReaderFailOnMissingInformer: true},
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "73d6b7ce.openstack.org",
 		WebhookServer: webhook.NewServer(


### PR DESCRIPTION
When controller makes queries with client.{Get,List} on resources haven’t been declared upfront, controller-runtime will initialize an informer on-the-fly and block on warming up its cache. This leads to issues like:

* controller-runtime starting a watch for a resource type and start caching all its objects in memory (even if you were trying to query only one resource), potentially leading to the process running out of memory.
* unpredictable reconciliation times while the informer cache is syncing, during which your worker goroutine will be blocked from reconciling other resources.