### PR TITLE
Do not update the status when reconciler exits due to panic

### DIFF
--- a/controllers/placementapi_controller.go
+++ b/controllers/placementapi_controller.go
@@ -223,6 +223,11 @@ func (r *PlacementAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
+			panic(r)
+		}
 		// update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(


### PR DESCRIPTION
As of now, we use deffered call to always update the status field when Reconcile call exist, which seems correct for any other error except when Reconciler exits due to panic.

This change adds a call to recover function and try to handle panic and log error.

Closes: [OSPRH-12982](https://issues.redhat.com//browse/OSPRH-12982)