### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -112,26 +112,26 @@ func CreateNames(placementAPIName types.NamespacedName) Names {
 	}
 }
 
-func GetDefaultPlacementAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultPlacementAPISpec() map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
 		"databaseAccount":  AccountName,
 	}
 }
 
-func GetTLSPlacementAPISpec(names Names) map[string]interface{} {
-	return map[string]interface{}{
+func GetTLSPlacementAPISpec(names Names) map[string]any {
+	return map[string]any{
 		"databaseInstance": "openstack",
 		"replicas":         1,
 		"secret":           SecretName,
 		"databaseAccount":  AccountName,
-		"tls": map[string]interface{}{
-			"api": map[string]interface{}{
-				"internal": map[string]interface{}{
+		"tls": map[string]any{
+			"api": map[string]any{
+				"internal": map[string]any{
 					"secretName": names.InternalCertSecretName.Name,
 				},
-				"public": map[string]interface{}{
+				"public": map[string]any{
 					"secretName": names.PublicCertSecretName.Name,
 				},
 			},
@@ -140,12 +140,12 @@ func GetTLSPlacementAPISpec(names Names) map[string]interface{} {
 	}
 }
 
-func CreatePlacementAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreatePlacementAPI(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "placement.openstack.org/v1beta1",
 		"kind":       "PlacementAPI",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -185,16 +185,16 @@ func PlacementConditionGetter(name types.NamespacedName) condition.Conditions {
 // want to avoid by default
 // 2. Usually a topologySpreadConstraints is used to take care about
 // multi AZ, which is not applicable in this context
-func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+func GetSampleTopologySpec(label string) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"service":  placement.ServiceName,
 						"topology": label,
 					},

--- a/tests/functional/placementapi_controller_test.go
+++ b/tests/functional/placementapi_controller_test.go
@@ -248,7 +248,7 @@ var _ = Describe("PlacementAPI controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultPlacementAPISpec()
 			spec["customServiceConfig"] = "foo = bar"
-			spec["defaultConfigOverwrite"] = map[string]interface{}{
+			spec["defaultConfigOverwrite"] = map[string]any{
 				"policy.yaml": "\"placement:resource_providers:list\": \"!\"",
 			}
 			DeferCleanup(th.DeleteInstance, CreatePlacementAPI(names.PlacementAPIName, spec))
@@ -667,8 +667,8 @@ var _ = Describe("PlacementAPI controller", func() {
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
 
 			spec := GetDefaultPlacementAPISpec()
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["internal"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["internal"] = map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"dnsmasq.network.openstack.org/hostname": "placement-internal.openstack.svc",
@@ -681,12 +681,12 @@ var _ = Describe("PlacementAPI controller", func() {
 						"service":  "placement",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -754,12 +754,12 @@ var _ = Describe("PlacementAPI controller", func() {
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(namespace))
 
 			spec := GetDefaultPlacementAPISpec()
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["public"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["public"] = map[string]any{
 				"endpointURL": "http://placement-openstack.apps-crc.testing",
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 
@@ -996,7 +996,7 @@ var _ = Describe("PlacementAPI controller", func() {
 	When("A PlacementAPI is created with a wrong topologyref", func() {
 		BeforeEach(func() {
 			spec := GetDefaultPlacementAPISpec()
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": "foo",
 			}
 			placement := CreatePlacementAPI(names.PlacementAPIName, spec)
@@ -1041,7 +1041,7 @@ var _ = Describe("PlacementAPI controller", func() {
 				infra.CreateTopology(t, topologySpec)
 			}
 			spec := GetDefaultPlacementAPISpec()
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			placement := CreatePlacementAPI(names.PlacementAPIName, spec)
@@ -1166,7 +1166,7 @@ var _ = Describe("PlacementAPI controller", func() {
 	When("A PlacementAPI is created with nodeSelector", func() {
 		BeforeEach(func() {
 			spec := GetDefaultPlacementAPISpec()
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
 

--- a/tests/functional/placementapi_webhook_test.go
+++ b/tests/functional/placementapi_webhook_test.go
@@ -82,14 +82,14 @@ var _ = Describe("PlacementAPI Webhook", func() {
 
 	It("rejects PlacementAPI with wrong defaultConfigOverwrite", func() {
 		spec := GetDefaultPlacementAPISpec()
-		spec["defaultConfigOverwrite"] = map[string]interface{}{
+		spec["defaultConfigOverwrite"] = map[string]any{
 			"policy.yaml":   "support",
 			"api-paste.ini": "not supported",
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "placement.openstack.org/v1beta1",
 			"kind":       "PlacementAPI",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      placementAPIName.Name,
 				"namespace": placementAPIName.Namespace,
 			},
@@ -114,17 +114,17 @@ var _ = Describe("PlacementAPI Webhook", func() {
 
 	It("rejects with wrong service override endpoint type", func() {
 		spec := GetDefaultPlacementAPISpec()
-		spec["override"] = map[string]interface{}{
-			"service": map[string]interface{}{
-				"internal": map[string]interface{}{},
-				"wrooong":  map[string]interface{}{},
+		spec["override"] = map[string]any{
+			"service": map[string]any{
+				"internal": map[string]any{},
+				"wrooong":  map[string]any{},
 			},
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "placement.openstack.org/v1beta1",
 			"kind":       "PlacementAPI",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      placementAPIName.Name,
 				"namespace": placementAPIName.Namespace,
 			},
@@ -194,14 +194,14 @@ var _ = Describe("PlacementAPI Webhook", func() {
 	It("rejects a wrong TopologyRef on a different namespace", func() {
 		spec := GetDefaultPlacementAPISpec()
 		// Inject a topologyRef that points to a different namespace
-		spec["topologyRef"] = map[string]interface{}{
+		spec["topologyRef"] = map[string]any{
 			"name":      "foo",
 			"namespace": "bar",
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "placement.openstack.org/v1beta1",
 			"kind":       "PlacementAPI",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      placementAPIName.Name,
 				"namespace": placementAPIName.Namespace,
 			},


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>