### PR TITLE
Pin base image to 9.6 tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.24
-ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
 # Build the manager binary
 FROM $GOLANG_BUILDER AS builder


### PR DESCRIPTION
The base image for latest tag got update to 9.7 where fips test started to fail. This pins it for now to the 9.6 tag