### PR TITLE
Bump golangci-lint to 2.7.2 for placement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     - id: go-mod-tidy
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.4.0
+  rev: v2.7.2
   hooks:
     - id: golangci-lint-full
       args: ["--verbose"]


### PR DESCRIPTION
## Summary
-Bump golangci-lint to 2.7.2