### PR TITLE
Add region_name support to Placement API config

### DIFF
--- a/internal/controller/placementapi_controller.go
+++ b/internal/controller/placementapi_controller.go
@@ -1370,6 +1370,7 @@ func (r *PlacementAPIReconciler) generateServiceConfigMaps(
 		"KeystonePublicURL":   keystonePublicURL,
 		"PlacementPassword":   string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]),
 		"log_file":            "/var/log/placement/placement-api.log",
+		"Region":              keystoneAPI.GetRegion(),
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,
 			string(dbSecret.Data[mariadbv1.DatabasePasswordSelector]),

--- a/templates/placementapi/config/placement.conf
+++ b/templates/placementapi/config/placement.conf
@@ -20,6 +20,9 @@ user_domain_name = Default
 project_name = service
 username = {{ .ServiceUser }}
 password = {{ .PlacementPassword }}
+{{ if (index . "Region") -}}
+region_name = {{ .Region }}
+{{ end -}}
 www_authenticate_uri = {{ .KeystonePublicURL }}
 auth_url = {{ .KeystoneInternalURL }}
 auth_type = password


### PR DESCRIPTION
- Add region_name to [keystone_authtoken] section in placement.conf
- Update placementapi_controller.go to pass Region to templateParameters

This ensures proper region selection in multi-region deployments for Keystone authentication.