### PR TITLE
Remove ci-approvers from OWNERS and OWNERS_ALIAS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
-  - ci-approvers
   - openstack-approvers
   - compute-approvers
 
 reviewers:
-  - ci-approvers
   - openstack-approvers
   - compute-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,9 +1,6 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
 
 aliases:
-  ci-approvers:
-  - frenzyfriday
-  - viroel
   openstack-approvers:
   - abays
   - dprince


### PR DESCRIPTION
ci-approvers alias currently points out to older members from CI.