### PR TITLE
Allow triggering the build workflow manually of needed

### DIFF
--- a/.github/workflows/build-placement-operator.yaml
+++ b/.github/workflows/build-placement-operator.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '*'
+  workflow_dispatch:  # This allows manual triggering from the Actions tab if needed
 
 env:
   imageregistry: 'quay.io'


### PR DESCRIPTION
There was an issue in github which is probably the root cause why an image for a merged PR was not running. This PR allows to trigger the job from the Actions tab in github.