### PR TITLE
Sync envtest optimization across all operators

### DIFF
--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -114,6 +114,10 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
+		// Increase this to 60 or 120 seconds for the single-core run
+		ControlPlaneStartTimeout: 120 * time.Second,
+		// Give it plenty of time to wind down (e.g., 60-120 seconds)
+		ControlPlaneStopTimeout: 120 * time.Second,
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "config", "crd", "bases"),
 			// NOTE(gibi): we need to list all the external CRDs our operator depends on
@@ -128,6 +132,14 @@ var _ = BeforeSuite(func() {
 			// the webhook fails as it try to parse the address as ipv4 and
 			// failing on the colons in ::1
 			LocalServingHost: "127.0.0.1",
+		},
+		ControlPlane: envtest.ControlPlane{
+			APIServer: &envtest.APIServer{
+				Args: []string{
+					"--service-cluster-ip-range=10.0.0.0/12", // 65k+ IPs
+					"--disable-admission-plugins=ResourceQuota,ServiceAccount,NamespaceLifecycle",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
With recent changes to the CI env we hit issues running envtest hitting timeouts in test since 25s was not enough, but also during kube-api startup and register custom CRDs before checks start and teardown of the kube-api. Therefore adding ControlPlaneStartTimeout and ControlPlaneStopTimeout bumping the default 60s to 120s.

Also hitting slow env and with our tests, we have seen that the default cluster ip range /24 is to small, increasing to /12

Also disable not required admission plugins for envtest: ResourceQuota: This stops the "quota evaluation timed out" error. The API server will no longer try to calculate how many resources exist before letting you create new ones.

ServiceAccount: This prevents the API server from looking for a ServiceAccount issuer or secret for every pod/resource. Since envtest doesn't run the ServiceAccount controller, this plugin often just causes unnecessary errors or delays.

NamespaceLifecycle: (Optional but recommended) This allows you to create resources in a namespace even if the namespace is in a "Terminating" state. This is very helpful when your cleanup is slow due to CPU throttling.